### PR TITLE
Adding percentage patterns from survey runner into design library

### DIFF
--- a/components/02-form-elements/input/README.md
+++ b/components/02-form-elements/input/README.md
@@ -1,0 +1,22 @@
+### Rationale
+Inputs are used where users enter answers to surveys
+
+### Variants
+Input variants can be added to input.config.js.
+
+### Status
+Default status is 'ready' but can be overridden for each variant.
+
+### Collated
+Collated is set to 'false' so each input has its own handlebars file.
+
+### Context
+Context vary for each input but label is used for human readable aspect and
+'label_text' is input content.
+
+### Scope
+Global
+
+### Dependencies
+* `/components/02-form-elements/input/_input.scss`
+* `/components/02-form-elements/input-type/_input-type.scss`

--- a/components/02-form-elements/input/input--percentage.hbs
+++ b/components/02-form-elements/input/input--percentage.hbs
@@ -1,0 +1,4 @@
+<div class="input-type input-type--percentage">
+  <input class="input input--number input-type__input" data-qa="input-number" pattern="[0-9]*" id="answer" name="answer" value="">
+  <abbr title="{{label}}" class="input-type__type" id="answer-type">{{label_text}}</abbr>
+</div>

--- a/components/02-form-elements/input/input.config.js
+++ b/components/02-form-elements/input/input.config.js
@@ -35,5 +35,12 @@ module.exports = {
       "label_text": "Select",
       "label_for": "select"
     },
+  }, {
+    "name": "percentage",
+    "status": "ready",
+    "context": {
+      "label": "Percentage",
+      "label_text": "%"
+    },
   }]
 }


### PR DESCRIPTION
Percentage pattern is added as an input to form elements. 


to test:
- run 'Yarn Start' on this branch 
- percentage should be added to 'Form Elements' > 'Input'