### PR TITLE
Adds component .scss files from eQ Runner not in SDC pattern library

### DIFF
--- a/components/answer/_answer.scss
+++ b/components/answer/_answer.scss
@@ -1,0 +1,19 @@
+.answer {
+  padding: 0;
+  margin-bottom: 1rem;
+  @include mq(m) {
+    margin-bottom: 2rem;
+  }
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+}
+
+.answer__guidance {
+  display: block;
+}
+
+.answer--calculated {
+  padding-top: 1rem;
+  border-top: 3px solid $color-borders;
+}

--- a/components/date/_date.scss
+++ b/components/date/_date.scss
@@ -1,0 +1,3 @@
+.date {
+  white-space: nowrap;
+}

--- a/components/feedback/_feedback.scss
+++ b/components/feedback/_feedback.scss
@@ -1,0 +1,33 @@
+.feedback__inline {
+  overflow: hidden;
+  width: 100%;
+  opacity: 0;
+  transition: max-height 500ms ease-out, opacity 500ms ease-out;
+  max-height: 0;
+  &.is-expanded {
+    max-height: 36em;
+    opacity: 1;
+    overflow: initial;
+  }
+  &.is-collapsed {
+    display: none;
+  }
+}
+
+.feedback__border {
+  border-bottom: 8px solid $color-secondary;
+  padding-bottom: 1rem;
+}
+
+.feedback__message {
+  margin: 3rem 0;
+}
+
+.feedback__field {
+  padding: 0;
+  margin-bottom: 1rem;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+}

--- a/components/form/_form.scss
+++ b/components/form/_form.scss
@@ -1,0 +1,3 @@
+.form {
+  margin-bottom: 1rem;
+}

--- a/components/guidance/_guidance.scss
+++ b/components/guidance/_guidance.scss
@@ -1,0 +1,78 @@
+.guidance {
+  margin: 0.7rem 0 0 -0.1rem;
+}
+
+.guidance__link {
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 1;
+  text-decoration: underline;
+  padding: 0.2rem 0.5rem 0.2rem 0.2rem;
+  span {
+    display: inline-block;
+    vertical-align: middle;
+  }
+  &::before {
+    $size: 1rem;
+
+    transition: transform 300ms ease-in-out;
+    margin-right: 0.3rem;
+    speak: none;
+    content: "";
+    background: url("#{$static}/img/icons/icons--guidance.svg") no-repeat center center;
+    background-size: auto;
+    text-align: center;
+    width: $size;
+    height: $size;
+    position: relative;
+    left: -0.1rem;
+    vertical-align: middle;
+    display: inline-block;
+  }
+
+  &:focus {
+    outline: none;
+    &::before {
+      background: url("#{$static}/img/icons/icons--guidance-white.svg") no-repeat center center;
+    }
+  }
+
+  .is-expanded & {
+    &::before {
+      transform: rotate(90deg);
+    }
+  }
+
+  .no-js & {
+    display: none;
+  }
+}
+
+.guidance__main {
+  overflow: hidden;
+  width: 100%;
+  border-radius: 3px;
+  opacity: 0;
+  transition: all 0;
+  max-height: 0;
+  margin-left: 0.5rem;
+  .no-js &,
+  .is-expanded & {
+    max-height: 10000em;
+    height: auto;
+    opacity: 1;
+    transition: opacity 300ms ease-out, max-height 300ms ease-out;
+  }
+}
+
+.guidance__content {
+  padding: 0;
+  width: 100%;
+  display: table;
+  table-layout: fixed;
+  margin-top: 1rem;
+  border-left: 2px solid $color-borders;
+  padding-left: 1rem;
+  margin-left: 1px;
+
+}

--- a/components/lock/_lock.scss
+++ b/components/lock/_lock.scss
@@ -1,0 +1,24 @@
+.lock {
+  display: block;
+  display: flex;
+  align-items: center;
+  font-weight: 700;
+  &::before {
+    $size: 2rem;
+    content: ' ';
+    display: inline-block;
+    vertical-align: middle;
+    background: $color-white url('#{$static}/img/icons/icons--lock.svg') no-repeat center center;
+    background-size: 2.2rem;
+    min-width: $size;
+    height: $size;
+    margin-right: 0.5em;
+  }
+}
+
+.lock__text {
+  display: inline-block;
+  vertical-align: middle;
+  font-size: 1rem;
+  line-height: 1.2;
+}

--- a/components/question/_question.scss
+++ b/components/question/_question.scss
@@ -1,0 +1,105 @@
+.question {
+  margin-bottom: 1rem;
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+  @include mq(m) {
+    margin-bottom: 2rem;
+  }
+}
+
+.question__error {
+  background: $color-red;
+  color: white;
+  font-size: 0.9rem;
+  padding: 0.5rem 1rem;
+}
+
+.question__legend {
+  margin-bottom: 1rem;
+  float: none;
+}
+
+.question__title {
+  position: relative;
+  clear: both;
+  // NOTE: do not enable display block as it breaks any instance
+  //       where this appears inside a `legend`
+  // display: block;
+  color: inherit;
+  margin-bottom: 1rem;
+  em {
+    background-color: $color-emphasis;
+  }
+}
+
+.question__number {
+  @include mq(xl) {
+    position: absolute;
+    text-align: right;
+    left: -100px;
+    width: 100px;
+    padding-right: 0.8rem;
+  }
+}
+
+.question__subtitle {
+  margin-top: 0.5rem;
+  clear: both;
+  display: block;
+  color: #888;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.question__description {
+  margin-bottom: 1rem;
+  clear: both;
+}
+
+.question__guidance {
+  margin-bottom: 2rem;
+  clear: both;
+}
+
+.question__actions {
+  margin-top: 1rem;
+  @include mq(s) {
+    margin-top: 2rem;
+  }
+}
+
+.question__answers {
+  clear: both;
+}
+
+.question__answer {
+  margin: 0 0 1rem;
+  transition: opacity 300ms ease-in-out;
+  opacity: 1;
+  &.is-hidden {
+    opacity: 0;
+  }
+  &.is-removed {
+    transition-duration: 500ms;
+    opacity: 0.5;
+  }
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+}
+
+.question--repeatinganswer {
+  .question__answer {
+    margin-bottom: 2rem;
+  }
+  .question__guidance--bottom {
+    margin: -1rem 0 0;
+  }
+  .answer {
+    margin-bottom: 1.5rem;
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  }
+}


### PR DESCRIPTION
### Context of this PR

The pattern library needed the addition of some `.scss` files that were not in the repository to bring it up to par with the eQ Runner styles. Until this has been completed and tested it will not be possible to use the CDN for eQ Runner.

__Files added:__

- `components/answer/_answer.scss`
- `components/date/_date.scss`
- `components/feedback/_feedback.scss`
- `components/form/_form.scss`
- `components/guidance/_guidance.scss`
- `components/lock/_lock.scss`
- `components/question/_question.scss`

### How to test

Compare the component .scss files with those from eQ Runner and that they appear in the output .css file.