### PR TITLE
Make Netlify Work

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "prestart": "yarn",
-    "build": "yarn prestart && gulp fractal:build",
+    "build": "yarn prestart && yarn compile_assets && gulp fractal:build",
     "compile_assets": "gulp",
     "start": "yarn && gulp dev",
     "deploy": "gulp && yarn build && gh-pages -d dist"


### PR DESCRIPTION
Adds the `compile_assets` step to the build task so that it actually has compiled assets to copy to the dist folder.

Check it works:

https://deploy-preview-57--sdc-pattern-library.netlify.com/