### PR TITLE
Corrected highlight to use em and updated notes for usage

### DIFF
--- a/components/highlight/README.md
+++ b/components/highlight/README.md
@@ -1,12 +1,15 @@
 ### Rationale
-Highlights are used to draw information to the attention of the user.
+Highlights are visual emphasis used to draw information to the attention of the user.
 
 ### Research
 
 ### Usage
 Highlight is used in eQ to draw the attention of the user to a particular value or phrase which is central to the understanding of the sentence. It is used to highlight a section of a sentence or phrase which a user may otherwise miss.
 
-Highlight is also used to indicate a calculated or piped value which was entered previously and is being displayed in a new context. 
+Highlight is also used to indicate a calculated or piped value which was entered previously and is being displayed in a new context.
+
+#### Note
+> It should be noted that highlight should be applied to an `<em>` element. If it is applied to another element which does not carry semantic emphasis (for example `<span>`) it will fail in its intent as it no longer provides emphasis to all users.
 
 #### Scope
 Global

--- a/components/highlight/highlight.config.js
+++ b/components/highlight/highlight.config.js
@@ -2,9 +2,9 @@ module.exports = {
   title: "Highlight",
   status: "ready",
   context: {
-    "highlightcontent": "This is some <span class=\"highlight\">important</span> content.",
-    "highlightcontent-heading": "What was the value of the business’s total sales of <span class=\"highlight\">food</span>?",
-    "highlightcontent-heading2": "What was the value of the business’s total sales of <span class=\"highlight\">alcohol, tobacco and confectionary</span>?",
-    "highlightcontent-total": "Of the <span class=\"highlight\">423</span> employees how many were part-time?"
+    "highlightcontent": "This is some <em class=\"highlight\">important</em> content.",
+    "highlightcontent-heading": "What was the value of the business’s total sales of <em class=\"highlight\">food</em>?",
+    "highlightcontent-heading2": "What was the value of the business’s total sales of <em class=\"highlight\">alcohol, tobacco and confectionary</em>?",
+    "highlightcontent-total": "Of the <em class=\"highlight\">423</em> employees how many were part-time?"
   }
 }


### PR DESCRIPTION
### What is the context of this PR?
Updated highlight to use `<em>` so that it is semantically correct. Highlight applied to `<span>` or other non-emphasising elements should be regarded as incorrect as it would be providing different experiences to different users.

### How to review 
Review `readme.md` amendments for clarity.