### PR TITLE
Fix the example group validation summary.

### DIFF
--- a/components/summary/summary--errors.hbs
+++ b/components/summary/summary--errors.hbs
@@ -71,12 +71,12 @@
           <div class="summary__question mars">What was the value of the business's total sales of clothing and footwear?</div>
         </div>
         <div class="grid__col col-8@xs col-4@m">
-          <div class="summary__answer venus">£100.00</div>
+          <div class="summary__answer venus">£50.00</div>
         </div>
         <div class="grid__col col-4@xs col-2@m">
           <div class="summary__link mars">
             <a href="#edit">
-              Change <span class="u-vh">your answer for: What was the value of the business's total sales of clothing and footwear?. The current value is: £100.00</span>
+              Change <span class="u-vh">your answer for: What was the value of the business's total sales of clothing and footwear?. The current value is: £50.00</span>
             </a>
           </div>
         </div>


### PR DESCRIPTION
Now contains invalid data to justify error message.

Existing error message indicated that £300+£200+£100 did not equal £600.