### PR TITLE
Allow for longer strings in duration type input

### DIFF
--- a/components/02-form-elements/duration/duration.config.js
+++ b/components/02-form-elements/duration/duration.config.js
@@ -3,12 +3,19 @@ module.exports = {
   'collated': false,
   'status': 'wip',
   'context': {
-    'label': 'Time',
+    'label_time': 'Time',
     'unit1': 'Hours',
     'unit1Title': 'Hours',
     'unit2': 'Mins',
     'unit2Title': 'Minutes',
     'unit3': 'Secs',
-    'unit3Title': 'Seconds'
+    'unit3Title': 'Seconds',
+    'label_period': 'Period',
+    'unit4': 'Days',
+    'unit4Title': 'Days',
+    'unit5': 'Months',
+    'unit5Title': 'Months',
+    'unit6': 'Years',
+    'unit6Title': 'Years'
   }
 };

--- a/components/02-form-elements/duration/duration.hbs
+++ b/components/02-form-elements/duration/duration.hbs
@@ -7,7 +7,7 @@
       <div class="input-type input-type--unit">
         <input data-qa="input-number"
                id="{{label}}1"
-               class="input input--number input--with-unit input--block"
+               class="input input--number input-type__input"
                name="{{label}}1"
                value=""
                pattern="[0-9]*"
@@ -20,7 +20,7 @@
       <div class="input-type input-type--unit">
         <input data-qa="input-number"
                id="{{label}}2"
-               class="input input--number input--with-unit input--block"
+               class="input input--number input-type__input"
                name="{{label}}2"
                value=""
                pattern="[0-9]*"
@@ -33,7 +33,7 @@
       <div class="input-type input-type--unit">
         <input data-qa="input-number"
                id="{{label}}3"
-               class="input input--number input--with-unit input--block"
+               class="input input--number input-type__input"
                name="{{label}}3"
                value=""
                pattern="[0-9]*"

--- a/components/02-form-elements/duration/duration.hbs
+++ b/components/02-form-elements/duration/duration.hbs
@@ -1,44 +1,90 @@
 <fieldset class="fieldgroup fieldgroup--duration">
 
-  <legend id="duration-label" class="fieldgroup__title venus">{{label}}</legend>
+  <legend id="duration-label" class="fieldgroup__title venus">{{label_time}}</legend>
 
   <div class="fieldgroup__fields">
-    <div class="field fieldgroup__hours">
+    <div class="field">
       <div class="input-type input-type--unit">
         <input data-qa="input-number"
-               id="{{label}}1"
-               class="input input--number input-type__input"
-               name="{{label}}1"
+               id="{{label_time}}1"
+               class="input input--number input--with-unit input--block"
+               name="{{label_time}}1"
                value=""
                pattern="[0-9]*"
-               aria-labelledby="duration-label {{label}}-type1" />
-        <abbr title="{{unit1Title}}" class="input-type__type input-type__type--duration" id="{{label}}-type1">{{unit1}}</abbr>
+               aria-labelledby="duration-label {{label_time}}-type1" />
+        <abbr title="{{unit1Title}}" class="input-type__type input-type__type--time" id="{{label_time}}-type1">{{unit1}}</abbr>
       </div>
     </div>
 
-    <div class="field fieldgroup__mins">
+    <div class="field">
       <div class="input-type input-type--unit">
         <input data-qa="input-number"
-               id="{{label}}2"
-               class="input input--number input-type__input"
-               name="{{label}}2"
+               id="{{label_time}}2"
+               class="input input--number input--with-unit input--block"
+               name="{{label_time}}2"
                value=""
                pattern="[0-9]*"
-               aria-labelledby="duration-label {{label}}-type2" />
-        <abbr title="{{unit2Title}}" class="input-type__type input-type__type--duration" id="{{label}}-type2">{{unit2}}</abbr>
+               aria-labelledby="duration-label {{label_time}}-type2" />
+        <abbr title="{{unit2Title}}" class="input-type__type input-type__type--time" id="{{label_time}}-type2">{{unit2}}</abbr>
       </div>
     </div>
 
-    <div class="field fieldgroup__secs">
+    <div class="field">
       <div class="input-type input-type--unit">
         <input data-qa="input-number"
-               id="{{label}}3"
-               class="input input--number input-type__input"
-               name="{{label}}3"
+               id="{{label_time}}3"
+               class="input input--number input--with-unit input--block"
+               name="{{label_time}}3"
                value=""
                pattern="[0-9]*"
-               aria-labelledby="duration-label {{label}}-type3" />
-        <abbr title="{{unit3Title}}" class="input-type__type input-type__type--duration" id="{{label}}-type3">{{unit3}}</abbr>
+               aria-labelledby="duration-label {{label_time}}-type3" />
+        <abbr title="{{unit3Title}}" class="input-type__type input-type__type--time" id="{{label_time}}-type3">{{unit3}}</abbr>
+      </div>
+    </div>
+  </div>
+</fieldset>
+
+<fieldset class="fieldgroup fieldgroup--duration u-mt-l">
+
+  <legend id="duration-label" class="fieldgroup__title venus">{{label_period}}</legend>
+
+  <div class="fieldgroup__fields">
+    <div class="field">
+      <div class="input-type input-type--unit">
+        <input data-qa="input-number"
+               id="{{label_period}}4"
+               class="input input--number input--with-unit input--block"
+               name="{{label_period}}4"
+               value=""
+               pattern="[0-9]*"
+               aria-labelledby="duration-label {{label_period}}-type4" />
+        <abbr title="{{unit4Title}}" class="input-type__type input-type__type--period" id="{{label_period}}-type4">{{unit4}}</abbr>
+      </div>
+    </div>
+
+    <div class="field">
+      <div class="input-type input-type--unit">
+        <input data-qa="input-number"
+               id="{{label_period}}5"
+               class="input input--number input--with-unit input--block"
+               name="{{label_period}}5"
+               value=""
+               pattern="[0-9]*"
+               aria-labelledby="duration-label {{label_period}}-type5" />
+        <abbr title="{{unit5Title}}" class="input-type__type input-type__type--period" id="{{label_period}}-type5">{{unit5}}</abbr>
+      </div>
+    </div>
+
+    <div class="field">
+      <div class="input-type input-type--unit">
+        <input data-qa="input-number"
+               id="{{label_period}}6"
+               class="input input--number input--with-unit input--block"
+               name="{{label_period}}6"
+               value=""
+               pattern="[0-9]*"
+               aria-labelledby="duration-label {{label_period}}-type6" />
+        <abbr title="{{unit6Title}}" class="input-type__type input-type__type--period" id="{{label_period}}-type6">{{unit6}}</abbr>
       </div>
     </div>
   </div>

--- a/components/02-form-elements/fields/field/_field.scss
+++ b/components/02-form-elements/fields/field/_field.scss
@@ -178,14 +178,12 @@ input:checked ~ .field__other {
 .fieldgroup--duration {
   @extend %abstract-fieldgroup-inline;
 
-  .fieldgroup__hours,
-  .fieldgroup__mins,
-  .fieldgroup__secs {
+  .field {
     position: relative;
     margin: 0 0.5rem 0 0;
     flex: 1 1 0;
     clear: right;
-
+    max-width: 8.5rem;
     @include mq(s) {
       margin-right: 1rem;
     }

--- a/components/02-form-elements/fields/field/_field.scss
+++ b/components/02-form-elements/fields/field/_field.scss
@@ -182,7 +182,6 @@ input:checked ~ .field__other {
   .fieldgroup__mins,
   .fieldgroup__secs {
     position: relative;
-    max-width: 8.389rem;
     margin: 0 0.5rem 0 0;
     flex: 1 1 0;
     clear: right;

--- a/components/02-form-elements/input-type/_input-type.scss
+++ b/components/02-form-elements/input-type/_input-type.scss
@@ -75,12 +75,15 @@
     }
   }
 
-  .input-type__type--duration {
-    width: auto;
-    padding: .6rem;
+  .input-type__type--time,
+  .input-type__type--period {
+    width: 3.5rem;
     @include mq(s) {
       left: auto;
       right: 1px;
     }
+  }
+  .input-type__type--period {
+    width: 4.3rem;
   }
 }

--- a/components/02-form-elements/input-type/_input-type.scss
+++ b/components/02-form-elements/input-type/_input-type.scss
@@ -76,7 +76,8 @@
   }
 
   .input-type__type--duration {
-    width: 3.5rem;
+    width: auto;
+    padding: .6rem;
     @include mq(s) {
       left: auto;
       right: 1px;

--- a/components/02-form-elements/input/_input.scss
+++ b/components/02-form-elements/input/_input.scss
@@ -146,7 +146,7 @@
 }
 
 .input--with-unit {
-  padding-right: 3rem;
+  padding-right: 4rem;
 }
 
 .no-js {


### PR DESCRIPTION
### What is the context of this PR?
Problem shown in screenshot below:
![image](https://user-images.githubusercontent.com/1015442/40490000-66ef2e02-5f62-11e8-8317-9f4d3f3a5d2e.png)

Solution - To maintain the input width i've created two duration types (and got rid of 3 that were not doing anything) which cater for time types (mins, secs, hours) and period types (days, months, years). 

![image](https://user-images.githubusercontent.com/1015442/40490721-3a1c2810-5f64-11e8-993f-4392aa140a5e.png)

### How to review 
Check that the solution works ok