### PR TITLE
Pins to node 8 for the CI build

### DIFF
--- a/ci/concourse.yml
+++ b/ci/concourse.yml
@@ -26,6 +26,7 @@ jobs:
         type: docker-image
         source:
           repository: node
+          tag: 8.11.2
 
       inputs:
       - name: sdc-global-design-patterns


### PR DESCRIPTION
### What is the context of this PR?
The CI build was failing due to pulling the latest node docker image and then the node-sass version not being compatible.

This is a temporary measure and we aim to upgrade other dependencies to work with the newer node version.