### PR TITLE
Update node version used in CI build

### DIFF
--- a/ci/concourse.yml
+++ b/ci/concourse.yml
@@ -26,7 +26,7 @@ jobs:
         type: docker-image
         source:
           repository: node
-          tag: 8.11.2
+          tag: 10.2.1
 
       inputs:
       - name: sdc-global-design-patterns


### PR DESCRIPTION
### What is the context of this PR?
Updates the pinned node version (#102) for the CI build to 10.2.1 (updated in #104)
