### PR TITLE
Added a separate gulp task to produce a minified bundle.js

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -327,7 +327,19 @@ const bundleScripts = watch => {
 
 gulp.task('scripts:bundle', () => bundleScripts(false));
 
-gulp.task('scripts', gulp.series('scripts:clean', 'scripts:bundle'));
+/* UGLIFY of bundled scripts
+    - run this after all scripts are bundled to produce a minified version
+*/
+gulp.task('scripts:uglify', function(done) {
+  gulp.src('public/assets/scripts/bundle.js')
+    .pipe(uglify())
+    .pipe(rename({ suffix: '.min' }))
+    .pipe(gulp.dest('public/assets/scripts'))
+    done();
+});
+/* END UGLIFY of bundled scripts */
+
+gulp.task('scripts', gulp.series('scripts:clean', 'scripts:bundle', 'scripts:uglify'));
 
 /*gulp.task('scripts:watch', () => bundleScripts(true));*/
 gulp.task('scripts:watch', (done) => {


### PR DESCRIPTION
### What is the context of this PR?
Bundled scripts were being left un-minified. 

Fix is to add a separate gulp task which:

- takes the completed bundled script (`public/assets/scripts/bundle.js`)
- produces a minified version using `uglify`,
  - appends a `.min` suffix
  - and places it in the `public/assets/scripts/` folder.

### How to review 
Pull this branch and run `yarn compile_assets` watch the `public/assets/scripts` folder and check that the minified file is produced.
Check cli for any errors.

#### Resolves
#114 