### PR TITLE
Defining link colour for skip to content

### DIFF
--- a/components/_preview-skip.hbs
+++ b/components/_preview-skip.hbs
@@ -1,0 +1,63 @@
+<!doctype html>
+<!--[if lt IE 7]>      <html lang="en-gb" dir="ltr" class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html lang="en-gb" dir="ltr" class="no-js lt-ie10 lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html lang="en-gb" dir="ltr" class="no-js lt-ie10 lt-ie9"> <![endif]-->
+<!--[if IE 9]>         <html lang="en-gb" dir="ltr" class="no-js lt-ie10"> <![endif]-->
+<!--[if gt IE 9]><!--> <html lang="en-gb" dir="ltr" class="no-js"> <!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+  <link rel="icon" type="image/png" href="{{ path '/assets/img/eq.png'}}" />
+  <title>{{ _target.title }} | {{ _config.project.title }}</title>
+
+  <!--[if (gt IE 9) | (IEMobile)]><!-->
+  <link href="{{ path '/assets/css/responsive.css' }}" rel="stylesheet">
+  <!--<![endif]-->
+  <!--[if (lte IE 9) & (!IEMobile)]>
+  <link href="{{ path '/assets/css/fixed.css' }}" rel="stylesheet">
+  <![endif]-->
+
+  <!--[if gt IE 8]><!-->
+  <script>document.documentElement.className = document.documentElement.className.replace('no-js','has-js')</script>
+  <!--<![endif]-->
+
+  <script>
+    window.__EQ_SESSION_TIMEOUT__ = 18;
+    window.__EQ_SESSION_TIMEOUT_PROMPT__ = 12;
+  </script>
+
+  <style>
+    .collator-item {
+      margin-bottom: 2rem;
+    }
+    .collator-title {
+      font-size: 1.2rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="page__content">
+      {{{ yield }}}
+      {{> @header}}
+        <div class="page__container container">
+          <main role="main" id="main" class="page__main">
+          <div class="grid grid--reverse">
+            <div class="grid__col col-4@m">
+              {{> @navigation }}
+            </div>
+            <div class="grid__col col-7@m pull-1@m">
+              <div class="u-mt-l">
+              {{> @paragraph}}
+            </div>
+            </div>
+          </div>
+        </main>
+        </div>
+
+  </div>
+  {{> @footer}}
+</div>
+<script src="{{ path '/assets/scripts/bundle.js' }}" charset="utf-8"></script>
+</body>
+</html>

--- a/components/skip/_skip.scss
+++ b/components/skip/_skip.scss
@@ -23,5 +23,6 @@
     max-height: 20em;
     height: auto;
     top: 0;
+    color: $color-white;
   }
 }

--- a/components/skip/skip.config.js
+++ b/components/skip/skip.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  title: "Skip to content",
+  label: "Skip to content",
+  name: "skip",
+  "collated": true,
+  status: "ready",
+  "preview": "@preview-skip"
+}

--- a/components/skip/skip.hbs
+++ b/components/skip/skip.hbs
@@ -1,0 +1,5 @@
+<!-- Skip to content component -->
+<div class="skip">
+  <a class="skip__link" href="#main">Skip to content</a>
+</div>
+<!-- /Skip to content component -->


### PR DESCRIPTION
### What is the context of this PR?
Explicitly defining link colour for the 'Skip to content' link as it is displayed on a dark background on business and Census surveys.

### How to review 
Use the Netlify preview link to view the 'Skip to content' component in the pattern library and test the skip to content link.

### Issue
Resolves #118 