### PR TITLE
overflow:hidden removed from definition component

### DIFF
--- a/assets/sass/partials/behaviours/_details-toggle.scss
+++ b/assets/sass/partials/behaviours/_details-toggle.scss
@@ -43,11 +43,10 @@
   opacity: 0;
   transition: all 0;
   max-height: 0;
-  overflow: hidden;
   &::before,
   &::after {
     content: " ";
-    display: table; 
+    display: table;
   }
   &::after {
     clear: both;

--- a/components/definition/_definition.scss
+++ b/components/definition/_definition.scss
@@ -8,7 +8,7 @@
 
     &:focus {
       outline-offset: 3px;
-      outline: 3px solid $color-focus-outline;  
+      outline: 3px solid $color-focus-outline;
     }
   }
 
@@ -27,7 +27,8 @@
     /**
      * Hide extra close button when not expanded to stop it being focusable
      */
-    .definition__content-close-trigger {
+    .definition__content-close-trigger,
+    .definition__content {
       display: none;
     }
   }

--- a/components/details/_details.scss
+++ b/components/details/_details.scss
@@ -51,7 +51,6 @@
 }
 
 .details__main {
-  overflow: hidden;
   width: 100%;
   border-radius: 3px;
   opacity: 0;


### PR DESCRIPTION
### What is the context of this PR?
Removed the `overflow:hidden` from the definition component as this was obscuring the 'Close this' button offset highlight.

### How to review 
Test the definitions component.

### Issue(s):
Resolves #120 