### PR TITLE
added box-shadow to bridge the highlight offset on skip to content link

### DIFF
--- a/components/skip/_skip.scss
+++ b/components/skip/_skip.scss
@@ -24,5 +24,6 @@
     height: auto;
     top: 0;
     color: $color-white;
+    box-shadow: 0 3px 0 0 $color-white;
   }
 }


### PR DESCRIPTION
### What is the context of this PR?
Quick fix for the gap that is present between the skip to content link and the highlight.

### How to review 
Review the netlify build on different resolutions and devices.

### Issue(s)
Fixes #125 