### PR TITLE
Added checkbox example with 'other' option to pattern library

### DIFF
--- a/components/02-form-elements/input/input--checkbox-other.hbs
+++ b/components/02-form-elements/input/input--checkbox-other.hbs
@@ -1,0 +1,21 @@
+<div class="field field--checkbox field--multiplechoice">
+  <fieldset>
+    <legend class="field__legend mars">Select all that apply</legend>
+      {{#each options}}
+      <div class="field__item js-focusable-box">
+        <input class="input input--checkbox js-focusable" name="checkbox-answer" value="{{option_value}}" id="{{label_for}}" type="checkbox">
+        {{>@label}}
+      </div>
+      {{/each}}
+      <div class="field__item js-focusable-box">
+        <input id="checkbox-mandatory-answer-1" name="checkbox-answer" value="Other" data-qa="has-other-option" type="checkbox" class="input input--checkbox js-focusable ">
+        <label id="label-checkbox-mandatory-answer-1" class="label label--inline venus" for="checkbox-mandatory-answer-1">Other<br>
+          <span class="label__description label__inner pluto">An answer is required.</span>
+        </label>
+        <div class="field__other">
+          <label class="label mercury" for="other-answer-mandatory">Please specify other</label>
+          <input id="other-answer-mandatory" name="other-answer-mandatory" data-qa="other-option" type="text" class="input js-focusable">
+        </div>
+      </div>
+    </fieldset>
+</div>

--- a/components/02-form-elements/input/input.config.js
+++ b/components/02-form-elements/input/input.config.js
@@ -24,6 +24,18 @@ module.exports = {
       ]
     },
   }, {
+    "name": "checkbox-other",
+    'label': 'Checkbox (other)',
+    "context": {
+      "label_text": "Bacon",
+      "label_for": "checkbox",
+      "label_inline": true,
+      "options": [
+        {"option_text":"Bacon", "option_value": "bacon", "label_for":"bacon", "label_text":"Bacon", "label_inline":true},
+        {"option_text":"Olives", "option_value": "olives", "label_for":"olives", "label_text":"Olives", "label_inline":true},
+      ]
+    },
+  }, {
     'name': 'radio',
     'status': 'ready',
     'context': {


### PR DESCRIPTION
### What is the context of this PR?
The pattern library was missing an example of a set of checkbox inputs with an "other" option.

![image](https://user-images.githubusercontent.com/1015442/42560645-004ca2b2-84ef-11e8-8eae-1153518359c6.png)


### How to review 
Check that the example works as required.