### PR TITLE
Addition of max-width property to avoid out of bounds resizing.

### DIFF
--- a/components/02-form-elements/input/_input.scss
+++ b/components/02-form-elements/input/_input.scss
@@ -49,6 +49,7 @@
 
 .input--textarea {
   width: 100%;
+  max-width: 100%; /* To avoid this escaping bounds of container on resize */
 }
 
 .input--radio,
@@ -152,4 +153,3 @@
 .input__limit--reached {
   color: $color-red;
 }
-


### PR DESCRIPTION
### What is the context of this PR?
Define the max-width of the `textarea` element to avoid it resizing beyond the container.

### How to review 
Review the code in the .scss and the implementation in the textarea component on netlify.

### Issues
Resolves #159 