### PR TITLE
Added a .u-nowrap utility class

### DIFF
--- a/assets/sass/partials/utilities/_utilities.scss
+++ b/assets/sass/partials/utilities/_utilities.scss
@@ -18,6 +18,11 @@
   }
 }
 
+// Utility class to force non-wrapping of values
+.u-nowrap {
+  white-space: nowrap;
+}
+
 // Set an element's width to be auto at specified breakpoint
 @each $breakpointMin, $size in $grid-bp {
   @media only screen and (min-width: get-bp-width($breakpointMin)) {


### PR DESCRIPTION
### What is the context of this PR?
There is a need to disable the wrapping of financial or other unit based values to make them more legible/comprehensible.

### How to review 
Add the `u-nowrap` to a highlight and edit the copy to attempt to force a word-wrap.

### Issues
Resolves #160 