### PR TITLE
Removed display:block from summary__item, fixed PL view of mobile button

### DIFF
--- a/components/02-form-elements/textarea/character-limit.js
+++ b/components/02-form-elements/textarea/character-limit.js
@@ -50,7 +50,7 @@ domready(() => {
 
     forEach(limitedInputs, (input) => {
       const charLimitEl = document.querySelector(`#${input.getAttribute(attrCharLimitRef)}`)
-
+      console.log(input)
       input.setAttribute('data-maxlength', input.getAttribute('maxlength'))
       updateAvailableChars(input, charLimitEl)
       input.addEventListener('input', () => updateAvailableChars(input, charLimitEl))

--- a/components/02-form-elements/textarea/textarea.config.js
+++ b/components/02-form-elements/textarea/textarea.config.js
@@ -16,7 +16,7 @@ module.exports = {
     'label':'No character limit applied',
     'name':'no-maxchar',
     'context': {
-      'textarea_id' : 'textarea-answer-nomax',
+      'textarea_id' : 'textarea-answer-nomax'
     }
   }]
 }

--- a/components/04-navigation/header-navigation/header-navigation.config.js
+++ b/components/04-navigation/header-navigation/header-navigation.config.js
@@ -9,6 +9,7 @@ module.exports = {
     "name":"save",
     "context": {
       "button": "Save and sign out",
+      "no_bg" : true
     }
   },{
     "label":"Main",
@@ -47,6 +48,7 @@ module.exports = {
       "name":"combination",
       "context": {
         "button": "Save and sign out",
+        "no_bg" : true,
         "services":[
           {
             "text": "My account",
@@ -77,6 +79,7 @@ module.exports = {
         "internal": true,
         "classes": "header--internal",
         "button": "Save and sign out",
+        "no_bg" : true,
         "services":[
           {
             "text": "My account",

--- a/components/button/button--mobile.hbs
+++ b/components/button/button--mobile.hbs
@@ -1,1 +1,3 @@
-<button class="btn btn--mobile js-nav-btn {{btn-classes}}" type="button" id="menu-btn" aria-expanded="false" aria-controls="main-nav" aria-label="Toggle main navigation" aria-haspopup="true"><span class="btn--mobile__label">{{label}}</span></button>
+{{#unless no_bg}} <div class="bar u-pl-m u-pt-m u-pb-m">{{/unless}}
+    <button class="btn btn--mobile js-nav-btn {{btn-classes}}" type="button" id="menu-btn" aria-expanded="false" aria-controls="main-nav" aria-label="Toggle main navigation" aria-haspopup="true"><span class="btn--mobile__label">{{label}}</span></button>
+{{#unless no_bg}}</div>{{/unless}}  

--- a/components/summary/_summary.scss
+++ b/components/summary/_summary.scss
@@ -12,7 +12,6 @@
   border-radius: 0;
   position: relative;
   padding: 1rem 0;
-  display: block;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
### What is the context of this PR?
Small fix to remove `display:block` from `.summary__item`. It's not necessary and make overriding difficult.

Also fixed a small PL issue. The mobile button required a background to be visible.

### How to review 
Check the summary displays as it always has. There should be no difference.