### PR TITLE
Extended mutually exclusive js to work with all field types

### DIFF
--- a/components/02-form-elements/mutually-exclusive/mutually-exclusive--date.hbs
+++ b/components/02-form-elements/mutually-exclusive/mutually-exclusive--date.hbs
@@ -7,12 +7,12 @@
     <div class="fieldgroup__fields">
       <div class="field field--input field--day">
         <label class="label mercury" data-qa="label-day" for="date-range-from-day">{{day_label}}</label>
-        <input id="date-range-from-day" placeholder="DD" value="" data-qa="input-StringField" class="input input--StringField js-exclusive-group">
+        <input id="date-range-from-day" data-value="Day" placeholder="DD" value="" data-qa="input-StringField" class="input input--StringField js-exclusive-group">
       </div>
 
       <div class="field field--select field--month">
         <label class="label mercury" for="date-range-from-month" id="label-date-range-from-month" data-qa="label-month">{{month_label}}</label>
-        <select class="input input--select js-exclusive-group" id="date-range-from-month" name="date-range-from-month">
+        <select class="input input--select js-exclusive-group" data-value="month" id="date-range-from-month" name="date-range-from-month">
           {{#each months}}
             <option value="{{value}}"
               {{#if disabled}}disabled="disabled"{{/if}}
@@ -23,7 +23,7 @@
 
       <div class="field field--input field--year">
         <label class="label mercury" data-qa="label-year" for="date-range-from-year">{{year_label}}</label>
-        <input placeholder="YYYY" value="" data-qa="input-StringField" id="date-range-from-year" class="input input--StringField js-exclusive-group">
+        <input placeholder="YYYY" value="" data-qa="input-StringField" id="date-range-from-year" data-value="Year" class="input input--StringField js-exclusive-group">
       </div>
     </div>
   </div>

--- a/components/02-form-elements/mutually-exclusive/mutually-exclusive--date.hbs
+++ b/components/02-form-elements/mutually-exclusive/mutually-exclusive--date.hbs
@@ -1,0 +1,42 @@
+{{#if title}}<h2 class="saturn">When did you leave your last paid job?</h2>{{/if}}
+<fieldset class="field field--exclusive">
+  <legend class="field__legend mars u-vh">{{fieldset_legend}}</legend>
+  <div class="field__label venus">{{field_label}}</div>
+  
+  <div class="fieldgroup fieldgroup--date" data-qa="widget-date">
+    <div class="fieldgroup__fields">
+      <div class="field field--input field--day">
+        <label class="label mercury" data-qa="label-day">{{day_label}}</label>
+        <input placeholder="DD" value="" data-qa="input-StringField" class="input input--StringField js-exclusive-group">
+      </div>
+
+      <div class="field field--select field--month">
+        <label class="label mercury" for="date-range-from-month" id="label-date-range-from-month" data-qa="label-month">{{month_label}}</label>
+        <select class="input input--select js-exclusive-group" id="date-range-from-month" name="date-range-from-month">
+          {{#each months}}
+            <option value="{{value}}"
+              {{#if disabled}}disabled="disabled"{{/if}}
+              {{#if selected}}selected="selected"{{/if}}>{{label}}</option>
+          {{/each}}
+        </select>
+      </div>
+
+      <div class="field field--input field--year">
+        <label class="label mercury" data-qa="label-year">{{year_label}}</label>
+        <input placeholder="YYYY" value="" data-qa="input-StringField" class="input input--StringField js-exclusive-group">
+      </div>
+    </div>
+  </div>
+
+  <div class="field__label u-mt-s venus" aria-hidden="true">{{or}},</div>
+
+  <div class="field field--checkbox field--multiplechoice field--exclusive">
+    <div class="field__item js-focusable-box">
+      <input class="input input--checkbox js-focusable js-exclusive-checkbox" name="heating-type" value="{{or_option_value}}" id="none" type="checkbox">
+      <label class="label label--inline venus " for="none">
+          <span class="u-vh">{{or}},</span> {{or_option_text}}<span class="u-vh">. {{or_deselect_message}}</span>
+      </label>
+      <span class="js-exclusive-alert u-vh" role="alert" aria-live="polite" data-adjective="{{or_deselect_adjective}}"></span>
+    </div>
+  </div>
+</fieldset>

--- a/components/02-form-elements/mutually-exclusive/mutually-exclusive--date.hbs
+++ b/components/02-form-elements/mutually-exclusive/mutually-exclusive--date.hbs
@@ -6,8 +6,8 @@
   <div class="fieldgroup fieldgroup--date" data-qa="widget-date">
     <div class="fieldgroup__fields">
       <div class="field field--input field--day">
-        <label class="label mercury" data-qa="label-day">{{day_label}}</label>
-        <input placeholder="DD" value="" data-qa="input-StringField" class="input input--StringField js-exclusive-group">
+        <label class="label mercury" data-qa="label-day" for="date-range-from-day">{{day_label}}</label>
+        <input id="date-range-from-day" placeholder="DD" value="" data-qa="input-StringField" class="input input--StringField js-exclusive-group">
       </div>
 
       <div class="field field--select field--month">
@@ -22,8 +22,8 @@
       </div>
 
       <div class="field field--input field--year">
-        <label class="label mercury" data-qa="label-year">{{year_label}}</label>
-        <input placeholder="YYYY" value="" data-qa="input-StringField" class="input input--StringField js-exclusive-group">
+        <label class="label mercury" data-qa="label-year" for="date-range-from-year">{{year_label}}</label>
+        <input placeholder="YYYY" value="" data-qa="input-StringField" id="date-range-from-year" class="input input--StringField js-exclusive-group">
       </div>
     </div>
   </div>

--- a/components/02-form-elements/mutually-exclusive/mutually-exclusive.config.js
+++ b/components/02-form-elements/mutually-exclusive/mutually-exclusive.config.js
@@ -4,7 +4,7 @@ module.exports = {
   'status': 'ready',
   'variants': [{
     'name': 'checkboxes',
-    'label': 'Mutually exclusive - checkboxes',
+    'label': 'Checkboxes',
     'context': {
       'fieldset_legend': 'What type of central heating do you have?',
       'field_label': 'Select all that apply:',
@@ -22,7 +22,7 @@ module.exports = {
     }
   },{
     'name': 'date',
-    'label': 'Mutually exclusive - date',
+    'label': 'Date',
     'context': {
       'title': 'When did you leave your last job?',
       'fieldset_legend': 'When did you leave your last job?',

--- a/components/02-form-elements/mutually-exclusive/mutually-exclusive.config.js
+++ b/components/02-form-elements/mutually-exclusive/mutually-exclusive.config.js
@@ -1,21 +1,74 @@
 module.exports = {
   'title': 'Mutually exclusive question pattern',
-  'label': 'Mutually exclusive',
-  'name': 'mutually exclusive',
+  'default': 'checkboxes',
   'status': 'ready',
-  'context': {
-    'fieldset_legend': 'What type of central heating do you have?',
-    'field_label': 'Select all that apply:',
-    'or': 'Or',
-    'options': [
-      {'option_text': 'Gas', 'option_value': 'gas', 'label_for': 'gas', 'label_text': 'Gas', 'label_inline': true},
-      {'option_text': 'Electric', 'option_value': 'electric', 'label_for': 'electric', 'label_text': 'Electric', 'label_inline': true},
-      {'option_text': 'Solid fuel', 'option_value': 'solid-fuel', 'label_for': 'solid-fuel', 'label_text': 'Solid fuel', 'label_inline': true},
-      {'option_text': 'Other', 'option_value': 'other', 'label_for': 'other', 'label_text': 'Other', 'label_inline': true}
-    ],
-    'or_option_text':'No central heating',
-    'or_option_value':'no central heating',
-    'or_deselect_adjective': 'deselected',
-    'or_deselect_message': 'Selecting this will uncheck all other checkboxes'
-  }
+  'variants': [{
+    'name': 'checkboxes',
+    'label': 'Mutually exclusive - checkboxes',
+    'context': {
+      'fieldset_legend': 'What type of central heating do you have?',
+      'field_label': 'Select all that apply:',
+      'or': 'Or',
+      'options': [
+        {'option_text': 'Gas', 'option_value': 'gas', 'label_for': 'gas', 'label_text': 'Gas', 'label_inline': true},
+        {'option_text': 'Electric', 'option_value': 'electric', 'label_for': 'electric', 'label_text': 'Electric', 'label_inline': true},
+        {'option_text': 'Solid fuel', 'option_value': 'solid-fuel', 'label_for': 'solid-fuel', 'label_text': 'Solid fuel', 'label_inline': true},
+        {'option_text': 'Other', 'option_value': 'other', 'label_for': 'other', 'label_text': 'Other', 'label_inline': true}
+      ],
+      'or_option_text':'No central heating',
+      'or_option_value':'no central heating',
+      'or_deselect_adjective': 'deselected',
+      'or_deselect_message': 'Selecting this will uncheck all other checkboxes'
+    }
+  },{
+    'name': 'date',
+    'label': 'Mutually exclusive - date',
+    'context': {
+      'title': 'When did you leave your last job?',
+      'fieldset_legend': 'When did you leave your last job?',
+      'field_label': 'Select a date:',
+      'or': 'Or',
+      'day_label': 'Day',
+      'month_label': 'Month',
+      'year_label': 'Year',
+      'months': [{
+        'label': 'Select month',
+        'selected': true,
+        'disabled': true,
+        'value': ''
+      },
+      {
+        'label': 'January',
+        'value': '1'
+      },
+      {
+        'label': 'February',
+        'value': '2'
+      },
+      {
+        'label': 'March',
+        'value': '3'
+      },
+      {
+        'label': 'April',
+        'value': '4'
+      },
+      {
+        'label': 'May',
+        'value': '5'
+      },
+      {
+        'label': 'June',
+        'value': '6'
+      },
+      {
+        'label': 'July',
+        'value': '7'
+      }],
+      'or_option_text':'I have never had a paid job',
+      'or_option_value':'I have never had a paid job',
+      'or_deselect_adjective': 'deselected',
+      'or_deselect_message': 'Selecting this will remove any pre-selected date'
+    }
+  }]
 };

--- a/components/02-form-elements/mutually-exclusive/mutually-exclusive.hbs
+++ b/components/02-form-elements/mutually-exclusive/mutually-exclusive.hbs
@@ -3,7 +3,7 @@
     <legend class="field__legend mars u-vh">{{fieldset_legend}}</legend>
     <div class="field__label venus">{{field_label}}</div>
       {{#each options}}<div class="field__item js-focusable-box">
-        <input class="input input--checkbox js-focusable js-exclusive-checkbox-group" name="heating-type" value="{{option_value}}" id="{{label_for}}" type="checkbox">
+        <input class="input input--checkbox js-focusable js-exclusive-group" name="heating-type" value="{{option_value}}" id="{{label_for}}" type="checkbox">
         {{>@label}}
       </div>{{/each}}
       <div class="field__label u-mt-s venus" aria-hidden="true">{{or}}</div>
@@ -12,7 +12,7 @@
         <label class="label label--inline venus " for="none">
             <span class="u-vh">{{or}},</span> {{or_option_text}}<span class="u-vh">. {{or_deselect_message}}</span>
         </label>
-        <span class="js-exclusive-checkbox-alert u-vh" role="alert" aria-live="polite" data-adjective="{{or_deselect_adjective}}"></span>
+        <span class="js-exclusive-alert u-vh" role="alert" aria-live="polite" data-adjective="{{or_deselect_adjective}}"></span>
       </div>
   </fieldset>
 </div>

--- a/components/02-form-elements/mutually-exclusive/mutually-exclusive.js
+++ b/components/02-form-elements/mutually-exclusive/mutually-exclusive.js
@@ -1,9 +1,9 @@
 import domready from '../../../assets/js/domready';
 
-const exclusiveWrapperClass = 'field--exclusive'
-const exclusiveGroupClass = 'js-exclusive-group';
-const checkboxClass = 'js-exclusive-checkbox';
-const voiceOverAlertClass = 'js-exclusive-alert';
+export const exclusiveWrapperClass = 'field--exclusive'
+export const exclusiveGroupClass = 'js-exclusive-group';
+export const checkboxClass = 'js-exclusive-checkbox';
+export const voiceOverAlertClass = 'js-exclusive-alert';
 
 export default function mutuallyExclusiveInputs() {
   const exclusiveWrapperElements = document.getElementsByClassName(exclusiveWrapperClass);
@@ -13,14 +13,13 @@ export default function mutuallyExclusiveInputs() {
     const voiceOverAlertElement = exclusiveWrapperElement.getElementsByClassName(voiceOverAlertClass)[0];
     
     for (let exclusiveGroupElement of exclusiveGroupElements) {
-      exclusiveGroupElement.addEventListener('click', function() {
+      exclusiveGroupElement.addEventListener('change', function() {
         voiceOverAlertElement.innerHTML = '';
         inputToggle(checkboxElement, voiceOverAlertElement, 'checkbox');
       });
     }
 
     checkboxElement.addEventListener('click', function() {
-      voiceOverAlertElement.innerHTML = '';
       for (let exclusiveGroupElement of exclusiveGroupElements) {
         const elementType = exclusiveGroupElement.type;
         inputToggle(exclusiveGroupElement, voiceOverAlertElement, elementType);
@@ -29,7 +28,9 @@ export default function mutuallyExclusiveInputs() {
   }
 }
 
-const inputToggle = function(inputEl, voiceOverAlertEl, elType) {
+export const inputToggle = function(inputEl, voiceOverAlertEl, elType) {
+
+  let attr
   if (elType === 'checkbox' && inputEl.checked === true) {
     inputEl.checked = false;
     inputEl.parentElement.classList.remove('is-checked');
@@ -43,7 +44,13 @@ const inputToggle = function(inputEl, voiceOverAlertEl, elType) {
     inputEl.selectedIndex = 0;
   }
 
-  voiceOverAlertEl.append(inputEl.getAttribute('value') + ' ' + voiceOverAlertEl.getAttribute('data-adjective') + '. ');
+  if (elType === 'text' || elType === 'select-one') {
+    attr = inputEl.getAttribute('data-value')
+  } else {
+    attr = inputEl.getAttribute('value')
+  }
+  
+  voiceOverAlertEl.append(attr + ' ' + voiceOverAlertEl.getAttribute('data-adjective') + '. ');
 }
 
 domready(mutuallyExclusiveInputs);

--- a/components/02-form-elements/mutually-exclusive/mutually-exclusive.js
+++ b/components/02-form-elements/mutually-exclusive/mutually-exclusive.js
@@ -1,37 +1,49 @@
 import domready from '../../../assets/js/domready';
 
-const checkboxWrapperClass = 'field--exclusive'
-const checkboxGroupClass = 'js-exclusive-checkbox-group';
+const exclusiveWrapperClass = 'field--exclusive'
+const exclusiveGroupClass = 'js-exclusive-group';
 const checkboxClass = 'js-exclusive-checkbox';
-const voiceOverAlertClass = 'js-exclusive-checkbox-alert';
+const voiceOverAlertClass = 'js-exclusive-alert';
 
-export default function mutuallyExclusiveCheckboxes() {
-  const checkboxWrapperElements = document.getElementsByClassName(checkboxWrapperClass);
-  for (let checkboxWrapperElement of checkboxWrapperElements) {
-    const checkboxGroupElements = checkboxWrapperElement.getElementsByClassName(checkboxGroupClass);
-    const checkboxElement = checkboxWrapperElement.getElementsByClassName(checkboxClass)[0];
-    const voiceOverAlertElement = checkboxWrapperElement.getElementsByClassName(voiceOverAlertClass)[0];
-    for (let checkboxGroupElement of checkboxGroupElements) {
-      checkboxGroupElement.addEventListener('change', function() {
+export default function mutuallyExclusiveInputs() {
+  const exclusiveWrapperElements = document.getElementsByClassName(exclusiveWrapperClass);
+  for (let exclusiveWrapperElement of exclusiveWrapperElements) {
+    const exclusiveGroupElements = exclusiveWrapperElement.getElementsByClassName(exclusiveGroupClass);
+    const checkboxElement = exclusiveWrapperElement.getElementsByClassName(checkboxClass)[0];
+    const voiceOverAlertElement = exclusiveWrapperElement.getElementsByClassName(voiceOverAlertClass)[0];
+    
+    for (let exclusiveGroupElement of exclusiveGroupElements) {
+      exclusiveGroupElement.addEventListener('click', function() {
         voiceOverAlertElement.innerHTML = '';
-        checkboxToggle(checkboxElement, voiceOverAlertElement);
+        inputToggle(checkboxElement, voiceOverAlertElement, 'checkbox');
       });
     }
-    checkboxElement.addEventListener('change', function() {
+
+    checkboxElement.addEventListener('click', function() {
       voiceOverAlertElement.innerHTML = '';
-      for (let checkboxGroupElement of checkboxGroupElements) {
-        checkboxToggle(checkboxGroupElement, voiceOverAlertElement);
+      for (let exclusiveGroupElement of exclusiveGroupElements) {
+        const elementType = exclusiveGroupElement.type;
+        inputToggle(exclusiveGroupElement, voiceOverAlertElement, elementType);
       }
     });
   }
 }
 
-const checkboxToggle = function(checkboxEl, voiceOverAlertEl) {
-  if (checkboxEl.checked === true) {
-    checkboxEl.checked = false;
-    checkboxEl.parentElement.classList.remove('is-checked');
-    voiceOverAlertEl.append(checkboxEl.getAttribute('value') + ' ' + voiceOverAlertEl.getAttribute('data-adjective') + '. ');
+const inputToggle = function(inputEl, voiceOverAlertEl, elType) {
+  if (elType === 'checkbox' && inputEl.checked === true) {
+    inputEl.checked = false;
+    inputEl.parentElement.classList.remove('is-checked');
   }
+
+  if (elType === 'text') {
+    inputEl.value = '';
+  }
+
+  if (elType === 'select-one') {
+    inputEl.selectedIndex = 0;
+  }
+
+  voiceOverAlertEl.append(inputEl.getAttribute('value') + ' ' + voiceOverAlertEl.getAttribute('data-adjective') + '. ');
 }
 
-domready(mutuallyExclusiveCheckboxes);
+domready(mutuallyExclusiveInputs);

--- a/tests/karma/spec/mutuallyexclusive.spec.js
+++ b/tests/karma/spec/mutuallyexclusive.spec.js
@@ -1,244 +1,177 @@
-import {
-  mutuallyExclusiveInputs,
+import mutuallyExclusiveInputs, {
   exclusiveWrapperClass,
   exclusiveGroupClass,
   checkboxClass,
   voiceOverAlertClass,
+  inputToggle,
 } from '02-form-elements/mutually-exclusive/mutually-exclusive';
 
-const strTemplate = `
+const strCheckboxesTemplate = `
 
 <div class="field field--checkbox field--multiplechoice ${exclusiveWrapperClass}">
   <fieldset>
     <legend class="field__legend mars u-vh">What type of central heating do you have?</legend>
     <div class="field__label venus">Select all that apply:</div>
       <div class="field__item js-focusable-box">
-        <input class="input input--checkbox js-focusable js-exclusive-group" name="heating-type" value="gas" id="gas" type="checkbox">
+        <input class="input input--checkbox js-focusable ${exclusiveGroupClass}" name="heating-type" value="gas" id="gas" type="checkbox">
         <label class="label label--inline venus " for="gas">Gas</label>
       </div><div class="field__item js-focusable-box">
-        <input class="input input--checkbox js-focusable js-exclusive-group" name="heating-type" value="electric" id="electric" type="checkbox">
+        <input class="input input--checkbox js-focusable ${exclusiveGroupClass}" name="heating-type" value="electric" id="electric" type="checkbox">
         <label class="label label--inline venus " for="electric">Electric</label>
       </div><div class="field__item js-focusable-box">
-        <input class="input input--checkbox js-focusable js-exclusive-group" name="heating-type" value="solid-fuel" id="solid-fuel" type="checkbox">
+        <input class="input input--checkbox js-focusable ${exclusiveGroupClass}" name="heating-type" value="solid-fuel" id="solid-fuel" type="checkbox">
         <label class="label label--inline venus " for="solid-fuel">Solid fuel</label>
       </div><div class="field__item js-focusable-box">
-        <input class="input input--checkbox js-focusable js-exclusive-group" name="heating-type" value="other" id="other" type="checkbox">
+        <input class="input input--checkbox js-focusable ${exclusiveGroupClass}" name="heating-type" value="other" id="other" type="checkbox">
         <label class="label label--inline venus " for="other">Other</label>
       </div>
       <div class="field__label u-mt-s venus" aria-hidden="true">Or</div>
       <div class="field__item js-focusable-box">
-        <input class="input input--checkbox js-focusable js-exclusive-checkbox" name="heating-type" value="no central heating" id="none" type="checkbox">
+        <input class="input input--checkbox js-focusable ${checkboxClass}" name="heating-type" value="no central heating" id="none" type="checkbox">
         <label class="label label--inline venus " for="none">
             <span class="u-vh">Or,</span> No central heating<span class="u-vh">. Selecting this will uncheck all other checkboxes</span>
         </label>
-        <span class="js-exclusive-alert u-vh" role="alert" aria-live="polite" data-adjective="deselected"></span>
+        <span class=" ${voiceOverAlertClass} u-vh" role="alert" aria-live="polite" data-adjective="deselected"></span>
       </div>
   </fieldset>
-</div>
+</div>`;
 
-<div class="${classAccordion}">
-  <div class="accordion__controls">
-    <button class="${classAccordionToggleAll} btn btn--secondary btn--small accordion__control u-wa--@xs" data-ga="click" data-ga-category="Preview Survey" data-ga-action="Show all" data-close-all-label="Hide all" data-open-all-label="Show all" data-open="false" aria-hidden="true">Show all</button>
-  </div>
-  <div class="${classAccordionContent}">
+const strInputsTemplate = `
+<fieldset class="field ${exclusiveWrapperClass}">
+    <legend class="field__legend mars u-vh">When did you leave your last job?</legend>
+    <div class="field__label venus">Select a date:</div>
 
-    <h3 class="${classAccordionTitle}" data-js-accordion-event-label="First Item">
-      <span class="accordion__title-text">First Item</span>
-      <button class="${classToggle} btn btn--secondary btn--small accordion__title-right accordion-unhide@m u-wa--@xs" data-close-label="Hide" data-open-label="Show" aria-hidden="true">Show</button>
-    </h3>
-    <div class="${classAccordionBody}">
-      First item content
+    <div class="fieldgroup fieldgroup--date" data-qa="widget-date">
+        <div class="fieldgroup__fields">
+            <div class="field field--input field--day">
+                <label class="label mercury" data-qa="label-day" for="date-range-from-day">Day</label>
+                <input id="date-range-from-day" placeholder="DD" value="" data-qa="input-StringField" class="input input--StringField ${exclusiveGroupClass}">
+            </div>
+
+            <div class="field field--select field--month">
+                <label class="label mercury" for="date-range-from-month" id="label-date-range-from-month" data-qa="label-month">Month</label>
+                <select class="input input--select ${exclusiveGroupClass}" id="date-range-from-month" name="date-range-from-month">
+            <option value=""
+              disabled="disabled"
+              selected="selected">Select month</option>
+            <option value="1">January</option>
+            <option value="2">February</option>
+            <option value="3">March</option>
+            <option value="4">April</option>
+            <option value="5">May</option>
+            <option value="6">June</option>
+            <option value="7">July</option>
+        </select>
+            </div>
+
+            <div class="field field--input field--year">
+                <label class="label mercury" data-qa="label-year" for="date-range-from-year">Year</label>
+                <input placeholder="YYYY" value="" data-qa="input-StringField" id="date-range-from-year" class="input input--StringField  
+                ${exclusiveGroupClass}">
+            </div>
+        </div>
     </div>
 
-    <h3 class="${classAccordionTitle}" data-js-accordion-event-label="Second Item">
-      <span class="accordion__title-text">Second Item</span>
-      <button class="${classToggle} btn btn--secondary btn--small accordion__title-right accordion-unhide@m u-wa--@xs" data-close-label="Hide" data-open-label="Show" aria-hidden="true">Show</button>
-    </h3>
-    <dd class="${classAccordionBody}">
-      Second item content
-    </dd>
-  </div>
-</div>
-`;
+    <div class="field__label u-mt-s venus" aria-hidden="true">Or,</div>
 
-let elTemplate;
+    <div class="field field--checkbox field--multiplechoice field--exclusive">
+        <div class="field__item js-focusable-box">
+            <input class="input input--checkbox js-focusable ${checkboxClass}" name="heating-type" value="I have never had a paid job" id="none" type="checkbox">
+            <label class="label label--inline venus " for="none">
+          <span class="u-vh">Or,</span> I have never had a paid job<span class="u-vh">. Selecting this will remove any pre-selected date</span>
+      </label>
+            <span class="${voiceOverAlertClass} u-vh" role="alert" aria-live="polite" data-adjective="deselected"></span>
+        </div>
+    </div>
+</fieldset>`;
 
-describe('Accordion;', function() {
-  before('Add template to DOM and stub analytics', function() {
+let elTemplate, checkboxElement, exclusiveGroupElement, voiceOverAlertElement;
+
+describe('Mutually Exclusive Checkboxes;', function() {
+
+  before('Add template to DOM', function() {
     let wrapper = document.createElement('div');
-    wrapper.innerHTML = strTemplate;
+    wrapper.innerHTML = strCheckboxesTemplate;
     elTemplate = wrapper;
     document.body.appendChild(elTemplate);
-
-    accordion((event, attr) => {
-      this.lastEvent = attr
-      this.lastEvent.name = event
-    });
+    mutuallyExclusiveInputs();
+    checkboxElement = document.getElementsByClassName(checkboxClass);
+    exclusiveGroupElement = document.getElementsByClassName(exclusiveGroupClass);
+    voiceOverAlertElement = document.getElementsByClassName(voiceOverAlertClass);
   });
 
   it('DOM should contain the template', function() {
     expect(document.body.contains(elTemplate)).to.equal(true);
   });
 
-  describe('When the accordion attaches to the DOM,', function() {
-
-    describe('Elements marked as content,', function() {
-      it('Should be assigned the "tablist" role', function() {
-        testAttributeValueEquals(classAccordionContent, 'role', 'tablist');
-      });
-
-      it('Should have an aria-multiselectable attribute set to true', function() {
-        testAttributeValueEquals(classAccordionContent, 'aria-multiselectable', 'true');
-      });
+  describe('When multiple checkboxes of the group are clicked,', function() {
+    exclusiveGroupElement = document.getElementsByClassName(exclusiveGroupClass);
+    before('Click the checkboxes', function() {
+      exclusiveGroupElement[0].click();
+      exclusiveGroupElement[1].click();
+      exclusiveGroupElement[2].click();
     });
 
-    describe('Elements marked as a title', function() {
-      it('Should be assigned the "tab" role', function() {
-        testAttributeValueEquals(classAccordionTitle, 'role', 'tab');
-      });
-
-      it('Should have an aria-expanded attribute set to false', function() {
-        testAttributeValueEquals(classAccordionTitle, 'aria-expanded', 'false');
-      });
-
-      it('Should have an aria-selected attribute set to false', function() {
-        testAttributeValueEquals(classAccordionTitle, 'aria-selected', 'false');
-      });
-    });
-
-    describe('Elements marked as a body', function() {
-      it('Should be assigned the "tabpanel" role', function() {
-        testAttributeValueEquals(classAccordionBody, 'role', 'tabpanel');
-      });
-
-      it('Should have an aria-hidden attribute set to true', function() {
-        testAttributeValueEquals(classAccordionBody, 'aria-hidden', 'true');
-      });
+    it('should update the live region', function() {
+      expect(voiceOverAlertElement[0]).should.not.be.empty;
     });
   });
 
-  describe('When the first title is clicked', function() {
-    before('Click the first title', function() {
-      this.titles = document.getElementsByClassName(classAccordionTitle);
-      this.titles[0].click();
+  describe('When the single override checkbox is clicked', function() {
+    before('Click the first checkbox', function() {
+      checkboxElement[0].click();
     });
 
-    it('should publish the open question event', function() {
-      expect(this.lastEvent.name).to.equal('send');
-      expect(this.lastEvent.eventCategory).to.equal('Preview Survey');
-      expect(this.lastEvent.eventAction).to.equal('Open question');
-      expect(this.lastEvent.eventLabel).to.equal('First Item');
-    });
-
-    it('should have an aria-expanded attribute set to true', function() {
-      expect(this.titles[0].getAttribute('aria-expanded')).to.equal('true');
-    });
-
-    it('should have an aria-selected attribute set to true', function() {
-      expect(this.titles[0].getAttribute('aria-selected')).to.equal('true');
-    });
-
-    describe('the associated body', function() {
-      before('get the associated body', function() {
-        this.body = document.getElementById(this.titles[0].getAttribute('aria-controls'));
-      });
-
-      it('should have an aria-hidden attribute set to false', function() {
-        expect(this.body.getAttribute('aria-hidden')).to.equal('false');
-      });
-
-      it('should not have the hidden class', function() {
-        expect(this.body.classList.contains(classHidden)).to.be.false;
-      });
-    });
-
-    describe('and the first title is clicked again,', () => {
-      before('Click the first title, again', function() {
-        this.titles[0].click();
-      });
-
-      it('should publish the close question event', function() {
-        expect(this.lastEvent.name).to.equal('send');
-        expect(this.lastEvent.eventCategory).to.equal('Preview Survey');
-        expect(this.lastEvent.eventAction).to.equal('Close question');
-        expect(this.lastEvent.eventLabel).to.equal('First Item');
-      });
-
-      it('should have an aria-expanded attribute set to false', function() {
-        expect(this.titles[0].getAttribute('aria-expanded')).to.equal('false');
-      });
-
-      it('should have an aria-selected attribute set to false', function() {
-        expect(this.titles[0].getAttribute('aria-selected')).to.equal('false');
-      });
-
-      describe('the associated body', function() {
-        before('get the associated body', function() {
-          this.body = document.getElementById(this.titles[0].getAttribute('aria-controls'));
-        });
-
-        it('should have an aria-hidden attribute set to true', function() {
-          expect(this.body.getAttribute('aria-hidden')).to.equal('true');
-        });
-
-        it('should have the hidden class', function() {
-          expect(this.body.classList.contains(classHidden)).to.be.false;
-        });
-      });
-    });
-  });
-
-  describe('When toggle all is clicked all items are open,', () => {
-    before("Click toggle all", function() {
-      this.openAlls = document.getElementsByClassName(classAccordionToggleAll);
-      this.openAlls[0].click();
-    });
-
-    it('All toggle all buttons data-open attribute should be true', function() {
-      for (let i=0; i < this.openAlls.length; i++) {
-        expect(this.openAlls[i].getAttribute('data-open')).to.equal('true');
-      }
-    });
-
-    it('All titles should have an aria-expanded attribute set to true', function() {
-      testAttributeValueEquals(classAccordionTitle, 'aria-expanded', 'true');
-    });
-
-    it('All titles should have an aria-selected attribute set to true', function() {
-      testAttributeValueEquals(classAccordionTitle, 'aria-selected', 'true');
-    });
-
-    it('All bodys should not have the hidden class', () => {
-      const bodys = document.getElementsByClassName(classAccordionBody);
-
-      for (let i=0; i < bodys.length; i++) {
-        expect(bodys[i].classList.contains(classHidden)).to.be.false;
-      }
-    });
-
-    it('All bodys should have an aria-hidden attribute set to false', () => {
-      testAttributeValueEquals(classAccordionBody, 'aria-hidden', 'false');
-    });
-
-    describe("and a Title is clicked", () => {
-      before("Click the first title", function() {
-        this.titles = document.getElementsByClassName(classAccordionTitle);
-        this.titles[0].click();
-      });
-
-      it('All toggle all buttons data-open attribute should be false', function() {
-        for (let i=0; i < this.openAlls.length; i++) {
-          expect(this.openAlls[i].getAttribute('data-open')).to.equal('false');
-        }
-      });
+    it('should uncheck the checkboxes in the group', function() {
+      expect(exclusiveGroupElement[0].checked).to.equal(false);
+      expect(exclusiveGroupElement[1].checked).to.equal(false);
+      expect(exclusiveGroupElement[2].checked).to.equal(false);
     });
   });
 });
 
-function testAttributeValueEquals(className, attribute, value) {
-  const elements = document.getElementsByClassName(className);
+describe('Mutually Exclusive Inputs;', function() {
 
-  for (let i=0; i < elements.length; i++) {
-    expect(elements[i].getAttribute(attribute)).to.equal(value);
-  }
-}
+  before('Add template to DOM', function() {
+    let wrapper = document.createElement('div');
+    wrapper.innerHTML = strInputsTemplate;
+    elTemplate = wrapper;
+    document.body.appendChild(elTemplate);
+  });
+
+  it('DOM should contain the template', function() {
+    expect(document.body.contains(elTemplate)).to.equal(true);
+  });
+
+  describe('When multiple fields of the group are given values,', function() {
+    exclusiveGroupElement = document.getElementsByClassName(exclusiveGroupClass);
+    before('Enter values into the fields', function() {
+      exclusiveGroupElement[4].value = '22';
+      exclusiveGroupElement[5].selectedIndex = 2;
+      exclusiveGroupElement[6].value = '1979';
+      console.log('Input values before:', exclusiveGroupElement[4].value, exclusiveGroupElement[5].selectedIndex, exclusiveGroupElement[6].value);
+    });
+    
+    it('should update the live region', function() {
+      expect(voiceOverAlertElement[1]).should.not.be.empty;
+    });
+  });
+
+  describe('When the single override checkbox is clicked', function() {
+    before('Click the first checkbox', function() {
+      checkboxElement[1].click();
+      inputToggle(exclusiveGroupElement[4], voiceOverAlertElement[1], 'text');
+      inputToggle(exclusiveGroupElement[5], voiceOverAlertElement[1], 'select-one');
+      inputToggle(exclusiveGroupElement[6], voiceOverAlertElement[1], 'text');
+    });
+
+    it('should clear all input fields', function() {
+        expect(exclusiveGroupElement[4].value).to.be.empty;
+        expect(exclusiveGroupElement[5].selectedIndex).to.equal(0);
+        expect(exclusiveGroupElement[6].value).to.be.empty;
+        console.log('Input values after:', exclusiveGroupElement[4].value, exclusiveGroupElement[5].value, exclusiveGroupElement[6].value);
+    }); 
+
+  });
+
+});

--- a/tests/karma/spec/mutuallyexclusive.spec.js
+++ b/tests/karma/spec/mutuallyexclusive.spec.js
@@ -1,0 +1,244 @@
+import {
+  mutuallyExclusiveInputs,
+  exclusiveWrapperClass,
+  exclusiveGroupClass,
+  checkboxClass,
+  voiceOverAlertClass,
+} from '02-form-elements/mutually-exclusive/mutually-exclusive';
+
+const strTemplate = `
+
+<div class="field field--checkbox field--multiplechoice ${exclusiveWrapperClass}">
+  <fieldset>
+    <legend class="field__legend mars u-vh">What type of central heating do you have?</legend>
+    <div class="field__label venus">Select all that apply:</div>
+      <div class="field__item js-focusable-box">
+        <input class="input input--checkbox js-focusable js-exclusive-group" name="heating-type" value="gas" id="gas" type="checkbox">
+        <label class="label label--inline venus " for="gas">Gas</label>
+      </div><div class="field__item js-focusable-box">
+        <input class="input input--checkbox js-focusable js-exclusive-group" name="heating-type" value="electric" id="electric" type="checkbox">
+        <label class="label label--inline venus " for="electric">Electric</label>
+      </div><div class="field__item js-focusable-box">
+        <input class="input input--checkbox js-focusable js-exclusive-group" name="heating-type" value="solid-fuel" id="solid-fuel" type="checkbox">
+        <label class="label label--inline venus " for="solid-fuel">Solid fuel</label>
+      </div><div class="field__item js-focusable-box">
+        <input class="input input--checkbox js-focusable js-exclusive-group" name="heating-type" value="other" id="other" type="checkbox">
+        <label class="label label--inline venus " for="other">Other</label>
+      </div>
+      <div class="field__label u-mt-s venus" aria-hidden="true">Or</div>
+      <div class="field__item js-focusable-box">
+        <input class="input input--checkbox js-focusable js-exclusive-checkbox" name="heating-type" value="no central heating" id="none" type="checkbox">
+        <label class="label label--inline venus " for="none">
+            <span class="u-vh">Or,</span> No central heating<span class="u-vh">. Selecting this will uncheck all other checkboxes</span>
+        </label>
+        <span class="js-exclusive-alert u-vh" role="alert" aria-live="polite" data-adjective="deselected"></span>
+      </div>
+  </fieldset>
+</div>
+
+<div class="${classAccordion}">
+  <div class="accordion__controls">
+    <button class="${classAccordionToggleAll} btn btn--secondary btn--small accordion__control u-wa--@xs" data-ga="click" data-ga-category="Preview Survey" data-ga-action="Show all" data-close-all-label="Hide all" data-open-all-label="Show all" data-open="false" aria-hidden="true">Show all</button>
+  </div>
+  <div class="${classAccordionContent}">
+
+    <h3 class="${classAccordionTitle}" data-js-accordion-event-label="First Item">
+      <span class="accordion__title-text">First Item</span>
+      <button class="${classToggle} btn btn--secondary btn--small accordion__title-right accordion-unhide@m u-wa--@xs" data-close-label="Hide" data-open-label="Show" aria-hidden="true">Show</button>
+    </h3>
+    <div class="${classAccordionBody}">
+      First item content
+    </div>
+
+    <h3 class="${classAccordionTitle}" data-js-accordion-event-label="Second Item">
+      <span class="accordion__title-text">Second Item</span>
+      <button class="${classToggle} btn btn--secondary btn--small accordion__title-right accordion-unhide@m u-wa--@xs" data-close-label="Hide" data-open-label="Show" aria-hidden="true">Show</button>
+    </h3>
+    <dd class="${classAccordionBody}">
+      Second item content
+    </dd>
+  </div>
+</div>
+`;
+
+let elTemplate;
+
+describe('Accordion;', function() {
+  before('Add template to DOM and stub analytics', function() {
+    let wrapper = document.createElement('div');
+    wrapper.innerHTML = strTemplate;
+    elTemplate = wrapper;
+    document.body.appendChild(elTemplate);
+
+    accordion((event, attr) => {
+      this.lastEvent = attr
+      this.lastEvent.name = event
+    });
+  });
+
+  it('DOM should contain the template', function() {
+    expect(document.body.contains(elTemplate)).to.equal(true);
+  });
+
+  describe('When the accordion attaches to the DOM,', function() {
+
+    describe('Elements marked as content,', function() {
+      it('Should be assigned the "tablist" role', function() {
+        testAttributeValueEquals(classAccordionContent, 'role', 'tablist');
+      });
+
+      it('Should have an aria-multiselectable attribute set to true', function() {
+        testAttributeValueEquals(classAccordionContent, 'aria-multiselectable', 'true');
+      });
+    });
+
+    describe('Elements marked as a title', function() {
+      it('Should be assigned the "tab" role', function() {
+        testAttributeValueEquals(classAccordionTitle, 'role', 'tab');
+      });
+
+      it('Should have an aria-expanded attribute set to false', function() {
+        testAttributeValueEquals(classAccordionTitle, 'aria-expanded', 'false');
+      });
+
+      it('Should have an aria-selected attribute set to false', function() {
+        testAttributeValueEquals(classAccordionTitle, 'aria-selected', 'false');
+      });
+    });
+
+    describe('Elements marked as a body', function() {
+      it('Should be assigned the "tabpanel" role', function() {
+        testAttributeValueEquals(classAccordionBody, 'role', 'tabpanel');
+      });
+
+      it('Should have an aria-hidden attribute set to true', function() {
+        testAttributeValueEquals(classAccordionBody, 'aria-hidden', 'true');
+      });
+    });
+  });
+
+  describe('When the first title is clicked', function() {
+    before('Click the first title', function() {
+      this.titles = document.getElementsByClassName(classAccordionTitle);
+      this.titles[0].click();
+    });
+
+    it('should publish the open question event', function() {
+      expect(this.lastEvent.name).to.equal('send');
+      expect(this.lastEvent.eventCategory).to.equal('Preview Survey');
+      expect(this.lastEvent.eventAction).to.equal('Open question');
+      expect(this.lastEvent.eventLabel).to.equal('First Item');
+    });
+
+    it('should have an aria-expanded attribute set to true', function() {
+      expect(this.titles[0].getAttribute('aria-expanded')).to.equal('true');
+    });
+
+    it('should have an aria-selected attribute set to true', function() {
+      expect(this.titles[0].getAttribute('aria-selected')).to.equal('true');
+    });
+
+    describe('the associated body', function() {
+      before('get the associated body', function() {
+        this.body = document.getElementById(this.titles[0].getAttribute('aria-controls'));
+      });
+
+      it('should have an aria-hidden attribute set to false', function() {
+        expect(this.body.getAttribute('aria-hidden')).to.equal('false');
+      });
+
+      it('should not have the hidden class', function() {
+        expect(this.body.classList.contains(classHidden)).to.be.false;
+      });
+    });
+
+    describe('and the first title is clicked again,', () => {
+      before('Click the first title, again', function() {
+        this.titles[0].click();
+      });
+
+      it('should publish the close question event', function() {
+        expect(this.lastEvent.name).to.equal('send');
+        expect(this.lastEvent.eventCategory).to.equal('Preview Survey');
+        expect(this.lastEvent.eventAction).to.equal('Close question');
+        expect(this.lastEvent.eventLabel).to.equal('First Item');
+      });
+
+      it('should have an aria-expanded attribute set to false', function() {
+        expect(this.titles[0].getAttribute('aria-expanded')).to.equal('false');
+      });
+
+      it('should have an aria-selected attribute set to false', function() {
+        expect(this.titles[0].getAttribute('aria-selected')).to.equal('false');
+      });
+
+      describe('the associated body', function() {
+        before('get the associated body', function() {
+          this.body = document.getElementById(this.titles[0].getAttribute('aria-controls'));
+        });
+
+        it('should have an aria-hidden attribute set to true', function() {
+          expect(this.body.getAttribute('aria-hidden')).to.equal('true');
+        });
+
+        it('should have the hidden class', function() {
+          expect(this.body.classList.contains(classHidden)).to.be.false;
+        });
+      });
+    });
+  });
+
+  describe('When toggle all is clicked all items are open,', () => {
+    before("Click toggle all", function() {
+      this.openAlls = document.getElementsByClassName(classAccordionToggleAll);
+      this.openAlls[0].click();
+    });
+
+    it('All toggle all buttons data-open attribute should be true', function() {
+      for (let i=0; i < this.openAlls.length; i++) {
+        expect(this.openAlls[i].getAttribute('data-open')).to.equal('true');
+      }
+    });
+
+    it('All titles should have an aria-expanded attribute set to true', function() {
+      testAttributeValueEquals(classAccordionTitle, 'aria-expanded', 'true');
+    });
+
+    it('All titles should have an aria-selected attribute set to true', function() {
+      testAttributeValueEquals(classAccordionTitle, 'aria-selected', 'true');
+    });
+
+    it('All bodys should not have the hidden class', () => {
+      const bodys = document.getElementsByClassName(classAccordionBody);
+
+      for (let i=0; i < bodys.length; i++) {
+        expect(bodys[i].classList.contains(classHidden)).to.be.false;
+      }
+    });
+
+    it('All bodys should have an aria-hidden attribute set to false', () => {
+      testAttributeValueEquals(classAccordionBody, 'aria-hidden', 'false');
+    });
+
+    describe("and a Title is clicked", () => {
+      before("Click the first title", function() {
+        this.titles = document.getElementsByClassName(classAccordionTitle);
+        this.titles[0].click();
+      });
+
+      it('All toggle all buttons data-open attribute should be false', function() {
+        for (let i=0; i < this.openAlls.length; i++) {
+          expect(this.openAlls[i].getAttribute('data-open')).to.equal('false');
+        }
+      });
+    });
+  });
+});
+
+function testAttributeValueEquals(className, attribute, value) {
+  const elements = document.getElementsByClassName(className);
+
+  for (let i=0; i < elements.length; i++) {
+    expect(elements[i].getAttribute(attribute)).to.equal(value);
+  }
+}


### PR DESCRIPTION
### What is the context of this PR?
Existing mutually exclusive functionality is scoped to `checkbox` input type.

Extended to work with `text` and `select` types.

### How to review 
Another example has been added to the pattern library under "Mutually exclusive" which demonstrates the mutually exclusive working with a date input which includes `text` and `select` input types.

Check that it works as expected and that the existing `checkbox` scenario works as expected.

### Screenshot

![image](https://user-images.githubusercontent.com/1015442/45748853-c91e5e80-bc01-11e8-82be-009832fd9c9b.png)
