### PR TITLE
Added after selector to the no-js class

### DIFF
--- a/components/collapsible/_collapsible.scss
+++ b/components/collapsible/_collapsible.scss
@@ -30,7 +30,7 @@
 
   .no-js & {
     padding-left: 0;
-    &::before,  &:hover::before {
+    &::before,  &:hover::before, &::after,  &:hover::after {
       background: none;
     }
     &--link + .collapsible__body {


### PR DESCRIPTION
### What is the context of this PR?
Small issue where the collapsible chevron was displayed on hover when javascript was disabled.

### How to review 
Turn off JS and check the feedback component.

The title should not display an icon on hover.