### PR TITLE
Fixed issue with unit inputs and updates readme

### DIFF
--- a/components/02-form-elements/duration/README.md
+++ b/components/02-form-elements/duration/README.md
@@ -4,6 +4,23 @@ Inline component for input values representing different units of time.
 ### Label
 Label is the full name of the unit and must be human readable.
 
+### Usage
+
+The duration `.fieldgroup` requires the additional `.fieldgroup--duration` class on the `<fieldset>` element.
+
+A `<div>` with the classes `input-type input-type--unit` is required to wrap the `<input>` and `<abbr>` elements.  
+
+The `<input>` element requires `input--with-unit input--block`. 
+
+The `<abbr>` element which contains the unit requires the classes `input-type__type input-type__type--group`.
+
+The default `<abbr>` width is set at `2.9rem`. There are two further width options which can be accessed using the following classes:
+
+`input-type__type--wide` - provides a width of `3.5rem` 
+
+`input-type__type--x-wide` - provides a width of `4.3rem`
+
+
 ### Scope
 Global
 

--- a/components/02-form-elements/duration/duration.hbs
+++ b/components/02-form-elements/duration/duration.hbs
@@ -12,7 +12,7 @@
                value=""
                pattern="[0-9]*"
                aria-labelledby="duration-label {{label_time}}-type1" />
-        <abbr title="{{unit1Title}}" class="input-type__type input-type__type--time" id="{{label_time}}-type1">{{unit1}}</abbr>
+        <abbr title="{{unit1Title}}" class="input-type__type input-type__type--group input-type__type--wide" id="{{label_time}}-type1">{{unit1}}</abbr>
       </div>
     </div>
 
@@ -25,7 +25,7 @@
                value=""
                pattern="[0-9]*"
                aria-labelledby="duration-label {{label_time}}-type2" />
-        <abbr title="{{unit2Title}}" class="input-type__type input-type__type--time" id="{{label_time}}-type2">{{unit2}}</abbr>
+        <abbr title="{{unit2Title}}" class="input-type__type input-type__type--group input-type__type--wide" id="{{label_time}}-type2">{{unit2}}</abbr>
       </div>
     </div>
 
@@ -38,7 +38,7 @@
                value=""
                pattern="[0-9]*"
                aria-labelledby="duration-label {{label_time}}-type3" />
-        <abbr title="{{unit3Title}}" class="input-type__type input-type__type--time" id="{{label_time}}-type3">{{unit3}}</abbr>
+        <abbr title="{{unit3Title}}" class="input-type__type input-type__type--group input-type__type--wide" id="{{label_time}}-type3">{{unit3}}</abbr>
       </div>
     </div>
   </div>
@@ -58,7 +58,7 @@
                value=""
                pattern="[0-9]*"
                aria-labelledby="duration-label {{label_period}}-type4" />
-        <abbr title="{{unit4Title}}" class="input-type__type input-type__type--period" id="{{label_period}}-type4">{{unit4}}</abbr>
+        <abbr title="{{unit4Title}}" class="input-type__type input-type__type--group input-type__type--x-wide" id="{{label_period}}-type4">{{unit4}}</abbr>
       </div>
     </div>
 
@@ -71,7 +71,7 @@
                value=""
                pattern="[0-9]*"
                aria-labelledby="duration-label {{label_period}}-type5" />
-        <abbr title="{{unit5Title}}" class="input-type__type input-type__type--period" id="{{label_period}}-type5">{{unit5}}</abbr>
+        <abbr title="{{unit5Title}}" class="input-type__type input-type__type--group input-type__type--x-wide" id="{{label_period}}-type5">{{unit5}}</abbr>
       </div>
     </div>
 
@@ -84,7 +84,7 @@
                value=""
                pattern="[0-9]*"
                aria-labelledby="duration-label {{label_period}}-type6" />
-        <abbr title="{{unit6Title}}" class="input-type__type input-type__type--period" id="{{label_period}}-type6">{{unit6}}</abbr>
+        <abbr title="{{unit6Title}}" class="input-type__type input-type__type--group input-type__type--x-wide" id="{{label_period}}-type6">{{unit6}}</abbr>
       </div>
     </div>
   </div>

--- a/components/02-form-elements/input-type/_input-type.scss
+++ b/components/02-form-elements/input-type/_input-type.scss
@@ -65,8 +65,10 @@
     border-left: 1px solid $color-borders;
     border-radius: 0 $input-radius $input-radius 0;
     @include mq(s) {
-      right: auto;
-      left: calc(#{$input-width - ($input-type-width) * 2} - 1px);
+      &:not(.input-type__type--group) {
+        right: auto;
+        left: calc(#{$input-width - ($input-type-width) * 2} - 1px);
+      }
     }
     @include fixed {
       left: $input-width - ($input-type-width);
@@ -75,15 +77,30 @@
     }
   }
 
-  .input-type__type--time,
-  .input-type__type--period {
+  .input-type__type--wide {
     width: 3.5rem;
     @include mq(s) {
-      left: auto;
-      right: 1px;
+      &:not(.input-type__type--group) {
+        left: calc(#{$input-width - ($input-type-width) * 2} - 12px);
+      }
     }
   }
-  .input-type__type--period {
+
+  .input-type__type--x-wide {
     width: 4.3rem;
+    @include mq(s) {
+      &:not(.input-type__type--group) {
+        left: calc(#{$input-width - ($input-type-width) * 2} - 27px);
+      }
+    }
+  }
+
+  .input-type__type--wide, .input-type__type--x-wide {
+    @include mq(s) {
+      &.input-type__type--group {
+        left: auto;
+        right: 1px;
+      }
+    }
   }
 }

--- a/components/02-form-elements/unit/README.md
+++ b/components/02-form-elements/unit/README.md
@@ -16,6 +16,20 @@ Label is the full name of the unit and must be human readable.
 ### Unit
 Unit is the localized symbol for each unit.
 
+### Usage
+
+A `<div>` with the classes `input-type input-type--unit` is required to wrap the `<input>` and `<abbr>` elements.  
+
+The `<input>` element requires `input-type__input`. 
+
+The `<abbr>` element which contains the unit requires the classes `input-type__type`.
+
+The default `<abbr>` width is set at `2.9rem`. There are two further width options which can be accessed using the following classes:
+
+`input-type__type--wide` - provides a width of `3.5rem` 
+
+`input-type__type--x-wide` - provides a width of `4.3rem`
+
 ### Scope
 Global
 


### PR DESCRIPTION
### What is the context of this PR?

A bug found where the `input-type__type--` was breaking when used in certain scenarios.

There was no `readme` for the usage.

### How to review 

Check the `duration` input types and `unit` input types work correctly. 

Check the `readme` makes sense.
