### PR TITLE
Refactored the unit input type to allow any string length

### DIFF
--- a/assets/sass/partials/vars/_forms.scss
+++ b/assets/sass/partials/vars/_forms.scss
@@ -1,4 +1,3 @@
 $input-radius: 3px;
 $input-padding: 0.6rem;
-$input-type-width: 2.9rem;
 $input-width: 19.5rem;

--- a/components/02-form-elements/duration/README.md
+++ b/components/02-form-elements/duration/README.md
@@ -8,17 +8,11 @@ Label is the full name of the unit and must be human readable.
 
 The duration `.fieldgroup` requires the additional `.fieldgroup--duration` class on the `<fieldset>` element.
 
-A `<div>` with the classes `input-type input-type--unit` is required to wrap the `<input>` and `<abbr>` elements.  
+A `<div>` with the classes `input-type input-type--unit input-type--group` is required to wrap the `<input>` and `<abbr>` elements.  
 
 The `<input>` element requires `input--with-unit input--block`. 
 
-The `<abbr>` element which contains the unit requires the classes `input-type__type input-type__type--group`.
-
-The default `<abbr>` width is set at `2.9rem`. There are two further width options which can be accessed using the following classes:
-
-`input-type__type--wide` - provides a width of `3.5rem` 
-
-`input-type__type--x-wide` - provides a width of `4.3rem`
+The `<abbr>` element which contains the unit requires the classes `input-type__type`.
 
 
 ### Scope

--- a/components/02-form-elements/duration/duration.hbs
+++ b/components/02-form-elements/duration/duration.hbs
@@ -4,7 +4,7 @@
 
   <div class="fieldgroup__fields">
     <div class="field">
-      <div class="input-type input-type--unit">
+      <div class="input-type input-type--unit input-type--group">
         <input data-qa="input-number"
                id="{{label_time}}1"
                class="input input--number input--with-unit input--block"
@@ -12,12 +12,12 @@
                value=""
                pattern="[0-9]*"
                aria-labelledby="duration-label {{label_time}}-type1" />
-        <abbr title="{{unit1Title}}" class="input-type__type input-type__type--group input-type__type--wide" id="{{label_time}}-type1">{{unit1}}</abbr>
+        <abbr title="{{unit1Title}}" class="input-type__type" id="{{label_time}}-type1">{{unit1}}</abbr>
       </div>
     </div>
 
     <div class="field">
-      <div class="input-type input-type--unit">
+      <div class="input-type input-type--unit input-type--group">
         <input data-qa="input-number"
                id="{{label_time}}2"
                class="input input--number input--with-unit input--block"
@@ -25,12 +25,12 @@
                value=""
                pattern="[0-9]*"
                aria-labelledby="duration-label {{label_time}}-type2" />
-        <abbr title="{{unit2Title}}" class="input-type__type input-type__type--group input-type__type--wide" id="{{label_time}}-type2">{{unit2}}</abbr>
+        <abbr title="{{unit2Title}}" class="input-type__type" id="{{label_time}}-type2">{{unit2}}</abbr>
       </div>
     </div>
 
     <div class="field">
-      <div class="input-type input-type--unit">
+      <div class="input-type input-type--unit input-type--group">
         <input data-qa="input-number"
                id="{{label_time}}3"
                class="input input--number input--with-unit input--block"
@@ -38,7 +38,7 @@
                value=""
                pattern="[0-9]*"
                aria-labelledby="duration-label {{label_time}}-type3" />
-        <abbr title="{{unit3Title}}" class="input-type__type input-type__type--group input-type__type--wide" id="{{label_time}}-type3">{{unit3}}</abbr>
+        <abbr title="{{unit3Title}}" class="input-type__type" id="{{label_time}}-type3">{{unit3}}</abbr>
       </div>
     </div>
   </div>
@@ -50,7 +50,7 @@
 
   <div class="fieldgroup__fields">
     <div class="field">
-      <div class="input-type input-type--unit">
+      <div class="input-type input-type--unit input-type--group">
         <input data-qa="input-number"
                id="{{label_period}}4"
                class="input input--number input--with-unit input--block"
@@ -63,7 +63,7 @@
     </div>
 
     <div class="field">
-      <div class="input-type input-type--unit">
+      <div class="input-type input-type--unit input-type--group">
         <input data-qa="input-number"
                id="{{label_period}}5"
                class="input input--number input--with-unit input--block"
@@ -71,12 +71,12 @@
                value=""
                pattern="[0-9]*"
                aria-labelledby="duration-label {{label_period}}-type5" />
-        <abbr title="{{unit5Title}}" class="input-type__type input-type__type--group input-type__type--x-wide" id="{{label_period}}-type5">{{unit5}}</abbr>
+        <abbr title="{{unit5Title}}" class="input-type__type" id="{{label_period}}-type5">{{unit5}}</abbr>
       </div>
     </div>
 
     <div class="field">
-      <div class="input-type input-type--unit">
+      <div class="input-type input-type--unit input-type--group">
         <input data-qa="input-number"
                id="{{label_period}}6"
                class="input input--number input--with-unit input--block"
@@ -84,7 +84,7 @@
                value=""
                pattern="[0-9]*"
                aria-labelledby="duration-label {{label_period}}-type6" />
-        <abbr title="{{unit6Title}}" class="input-type__type input-type__type--group input-type__type--x-wide" id="{{label_period}}-type6">{{unit6}}</abbr>
+        <abbr title="{{unit6Title}}" class="input-type__type" id="{{label_period}}-type6">{{unit6}}</abbr>
       </div>
     </div>
   </div>

--- a/components/02-form-elements/input-type/_input-type.scss
+++ b/components/02-form-elements/input-type/_input-type.scss
@@ -23,7 +23,7 @@ $width: $input-width;
     font-weight: 600;
     font-size: 1rem;
     text-align: center;
-    line-height: normal;
+    line-height: 1.2;
     position: absolute;
     right: 1px;
     top: 1px;

--- a/components/02-form-elements/input-type/_input-type.scss
+++ b/components/02-form-elements/input-type/_input-type.scss
@@ -29,6 +29,9 @@ $width: $input-width;
     top: 1px;
     z-index: 4;
     text-decoration: none;
+    @include ie8() {
+      line-height: 1.1;
+    }
   }
 }
 

--- a/components/02-form-elements/input-type/_input-type.scss
+++ b/components/02-form-elements/input-type/_input-type.scss
@@ -1,24 +1,16 @@
+$width: $input-width;
+
 .input-type {
   display: flex;
   position: relative;
   align-items: center;
 
   .input-type__input {
-    $width: calc(#{$input-width} - #{$input-type-width});
-
     border-radius: $input-radius;
     line-height: normal;
     position: relative;
     z-index: 3;
     width: 100%;
-    padding-left: $input-type-width + 0.5rem;
-    @include mq(s) {
-      width: $width;
-    }
-    @include fixed {
-      margin-left: 2.5rem;
-      border-left: 0;
-    }
   }
 
   .input-type__type {
@@ -26,32 +18,27 @@
     background-color: $color-lighter-grey;
     border-right: 1px solid $color-borders;
     border-radius: $input-radius 0 0 $input-radius;
-    padding: $input-padding 0;
-    width: $input-type-width;
+    padding: $input-padding;
+    width: auto;
     font-weight: 600;
     font-size: 1rem;
     text-align: center;
     line-height: normal;
     position: absolute;
-    left: 1px;
+    right: 1px;
     top: 1px;
     z-index: 4;
     text-decoration: none;
-    @include fixed {
-      left: 0;
-      width: 2.5rem;
-      height: 100%;
-      border: 1px solid $color-borders;
-    }
-    @include ie7 {
-      width: 1.15rem;
-      height: 1.15rem;
-    }
   }
 }
 
 .input-type--percentage,
 .input-type--unit {
+  @include mq(s) {
+    &:not(.input-type--group) {
+      width: $width;
+    }
+  }
   .input-type__input {
     padding-left: 0.5rem;
     @include fixed {
@@ -64,43 +51,5 @@
     border-right: none;
     border-left: 1px solid $color-borders;
     border-radius: 0 $input-radius $input-radius 0;
-    @include mq(s) {
-      &:not(.input-type__type--group) {
-        right: auto;
-        left: calc(#{$input-width - ($input-type-width) * 2} - 1px);
-      }
-    }
-    @include fixed {
-      left: $input-width - ($input-type-width);
-      top: 0;
-      border-right: 1px solid $color-borders;
-    }
-  }
-
-  .input-type__type--wide {
-    width: 3.5rem;
-    @include mq(s) {
-      &:not(.input-type__type--group) {
-        left: calc(#{$input-width - ($input-type-width) * 2} - 12px);
-      }
-    }
-  }
-
-  .input-type__type--x-wide {
-    width: 4.3rem;
-    @include mq(s) {
-      &:not(.input-type__type--group) {
-        left: calc(#{$input-width - ($input-type-width) * 2} - 27px);
-      }
-    }
-  }
-
-  .input-type__type--wide, .input-type__type--x-wide {
-    @include mq(s) {
-      &.input-type__type--group {
-        left: auto;
-        right: 1px;
-      }
-    }
   }
 }

--- a/components/02-form-elements/unit/README.md
+++ b/components/02-form-elements/unit/README.md
@@ -24,11 +24,6 @@ The `<input>` element requires `input-type__input`.
 
 The `<abbr>` element which contains the unit requires the classes `input-type__type`.
 
-The default `<abbr>` width is set at `2.9rem`. There are two further width options which can be accessed using the following classes:
-
-`input-type__type--wide` - provides a width of `3.5rem` 
-
-`input-type__type--x-wide` - provides a width of `4.3rem`
 
 ### Scope
 Global

--- a/components/02-form-elements/unit/unit.hbs
+++ b/components/02-form-elements/unit/unit.hbs
@@ -1,7 +1,7 @@
 <div class="field">
   {{> @label}}
   <div class="input-type input-type--unit">
-    <input data-qa="input-number" id="{{label}}" class="input input--number input-type__input" name="{{label}}" value="" pattern="[0-9]*">
+    <input data-qa="input-number" id="{{label}}" class="input input--number input--with-unit input-type__input" name="{{label}}" value="" pattern="[0-9]*">
     <abbr title="{{label}}" class="input-type__type" id="{{label}}-type">{{unit}}</abbr>
   </div>
 </div>


### PR DESCRIPTION
### What is the context of this PR?

After testing in runner the existing way the unit types were handled required reworking.

All width limits have now been removed to allow for any string length.

### How to review 
Check the unit and duration input components render as they should across browsers and viewports.

### Issue
Closes #77 