### PR TITLE
Fixed issue with padding on currency

### DIFF
--- a/components/02-form-elements/input-type/_input-type.scss
+++ b/components/02-form-elements/input-type/_input-type.scss
@@ -44,6 +44,7 @@ $width: $input-width;
   }
   .input-type__input {
     padding-left: 0.5rem;
+    padding-right: 4rem;
     @include fixed {
       margin-left: 0;
     }
@@ -63,8 +64,12 @@ $width: $input-width;
       width: calc(#{$width} - 3rem);
     }
   }
+  .input-type__input {
+    padding-left: 3.6rem;
+  }
   .input-type__type {
     right: auto;
     left: 1px;
+    width: 3rem;
   }
 }


### PR DESCRIPTION
### What is the context of this PR?
Left padding required for the `currency` input type.

### How to review 
Check it's ok.