### PR TITLE
Bug mutually exclusive select

### DIFF
--- a/components/02-form-elements/mutually-exclusive/mutually-exclusive.js
+++ b/components/02-form-elements/mutually-exclusive/mutually-exclusive.js
@@ -14,9 +14,8 @@ export default function mutuallyExclusiveInputs() {
     const voiceOverAlertElement = exclusiveWrapperElement.getElementsByClassName(voiceOverAlertClass)[0];
     for (let exclusiveGroupElement of exclusiveGroupElements) {
       const elementType = exclusiveGroupElement.type;
-      let event = elementType === 'checkbox' ? event = 'change' : event = 'keydown';
 
-      exclusiveGroupElement.addEventListener(event, function() {
+      exclusiveGroupElement.addEventListener('input', function() {
         voiceOverAlertElement.innerHTML = '';
         inputToggle(checkboxElement, voiceOverAlertElement, 'checkbox');
       });
@@ -37,18 +36,14 @@ export const inputToggle = function(inputEl, voiceOverAlertEl, elType) {
   if (elType === 'checkbox' && inputEl.checked === true) {
     inputEl.checked = false;
     inputEl.parentElement.classList.remove('is-checked');
-  }
-
-  if (elType === 'text' || elType === 'textarea') {
+  } else if (elType === 'text' || elType === 'textarea') {
     const charRef = document.querySelector(`#${inputEl.getAttribute(attrCharLimitRef)}`)
     attr = inputEl.getAttribute('data-value')
     inputEl.value = '';
     if (charRef) {  
       updateAvailableChars(inputEl, charRef);
     }
-  }
-
-  if (elType === 'select-one') {
+  } else if (elType === 'select-one') {
     inputEl.selectedIndex = 0;
     attr = inputEl.getAttribute('data-value')
   }

--- a/components/02-form-elements/mutually-exclusive/mutually-exclusive.js
+++ b/components/02-form-elements/mutually-exclusive/mutually-exclusive.js
@@ -13,8 +13,6 @@ export default function mutuallyExclusiveInputs() {
     const checkboxElement = exclusiveWrapperElement.getElementsByClassName(checkboxClass)[0];
     const voiceOverAlertElement = exclusiveWrapperElement.getElementsByClassName(voiceOverAlertClass)[0];
     for (let exclusiveGroupElement of exclusiveGroupElements) {
-      const elementType = exclusiveGroupElement.type;
-
       exclusiveGroupElement.addEventListener('input', function() {
         voiceOverAlertElement.innerHTML = '';
         inputToggle(checkboxElement, voiceOverAlertElement, 'checkbox');

--- a/components/02-form-elements/mutually-exclusive/mutually-exclusive.js
+++ b/components/02-form-elements/mutually-exclusive/mutually-exclusive.js
@@ -34,13 +34,16 @@ export const inputToggle = function(inputEl, voiceOverAlertEl, elType) {
   if (elType === 'checkbox' && inputEl.checked === true) {
     inputEl.checked = false;
     inputEl.parentElement.classList.remove('is-checked');
+
   } else if (elType === 'text' || elType === 'textarea') {
     const charRef = document.querySelector(`#${inputEl.getAttribute(attrCharLimitRef)}`)
     attr = inputEl.getAttribute('data-value')
     inputEl.value = '';
+
     if (charRef) {  
       updateAvailableChars(inputEl, charRef);
     }
+    
   } else if (elType === 'select-one') {
     inputEl.selectedIndex = 0;
     attr = inputEl.getAttribute('data-value')


### PR DESCRIPTION
### What is the context of this PR?
Small fix to change the event listener for the mutually exclusive to detect `input` instead of `keydown` and `change`.

The `input` type triggers on all types of user interaction with a form element. 

It is compatible down to ie9. For older versions it's the equivalent to the no js solution. 

### How to review 
Check all mutually exclusive examples work as expected.