### PR TITLE
Set a content-type of application json on expire session

### DIFF
--- a/components/timeout/timeout.dom.js
+++ b/components/timeout/timeout.dom.js
@@ -33,7 +33,7 @@ export default function timeoutDOM() {
     if (countDown < 1) {
       window.clearInterval(timeoutInterval);
 
-      fetch(SessionTimeoutUI.expireSessionUrl, { method: 'POST' })
+      fetch(SessionTimeoutUI.expireSessionUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' } })
         .then(() => {
           window.location = SessionTimeoutUI.sessionExpiredUrl;
         });


### PR DESCRIPTION
### What is the context of this PR?
[trello](https://trello.com/c/ASwVT0ss/2577-expire-session-being-blocked-by-the-waf)

The WAF is blocking requests which don't include a 'Content-Type' header.

Since the expire-session POST request has an empty body, the fetch API does not set a content-type header, and the request is being blocked by the WAF.

Though it is debatable whether a POST request with an empty body should have a content-type, in this case it's much easier to change our request than to change the WAF rule. The content-type of a request with no body is not properly specified by the W3C standard.

As discussed with Shane, the functionality here potentially shouldn't be in the pattern library at all, though that is likely a wider discussion.
