### PR TITLE
Move babel-polyfill to polyfills file to prevent duplicate error

### DIFF
--- a/assets/js/api/_load.js
+++ b/assets/js/api/_load.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import {subscribe} from './_sdcModules';
 import CountdownAnimation from '../../../components/countdown/countdown';
 import FormSubmitter from '../form-submitter';

--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import './focus-styles';
 import './dialog';
 import './submitter';

--- a/assets/js/polyfills.js
+++ b/assets/js/polyfills.js
@@ -1,3 +1,5 @@
+import 'babel-polyfill';
+
 /*
  * classList.js: Cross-browser full element.classList implementation.
  * 1.1.20150312


### PR DESCRIPTION
### What is the context of this PR?
Remove double import of babel-polyfill and place in polyfills file.
Fixes #221 
