### PR TITLE
Added temporary fix for month dropdown date input on mobile

### DIFF
--- a/components/02-form-elements/date/date.hbs
+++ b/components/02-form-elements/date/date.hbs
@@ -1,6 +1,6 @@
 <div class="answer answer--date">
   <div class="answer__fields js-fields">
-    <fieldset class="fieldgroup fieldgroup--inline" data-qa="widget-date"{{#if description}} aria-describedby="{{concatStr id '-description'}}"{{/if}} role="group">
+    <fieldset class="fieldgroup fieldgroup--inline fieldgroup--date" data-qa="widget-date"{{#if description}} aria-describedby="{{concatStr id '-description'}}"{{/if}} role="group">
       {{#if legend}}
       <legend class="fieldgroup__title u-fs-r--b">{{legend}}</legend>
       {{/if}}
@@ -17,7 +17,7 @@
         {{#if months}}
           <div class="field field--select">
             <label class="label u-fs-r" for="{{concatStr id '-month'}}" data-qa="label-month">{{monthLabel}}</label>
-            <select class="input input--select">
+            <select class="input input--select input--w-auto">
               <option selected disabled value="">{{firstOption}}</option>
               {{#each months}}
                 <option value="{{math @index '+' 1}}">{{this}}</option>

--- a/components/02-form-elements/fields/field/_field.scss
+++ b/components/02-form-elements/fields/field/_field.scss
@@ -99,6 +99,10 @@ input:checked ~ .field__other {
       flex-direction: column;
       justify-content: flex-end;
       margin: 0 $input-padding * 2 $input-padding * 2 0;
+
+      &:last-of-type {
+        margin-right: 0;
+      }
     }
   }
 
@@ -115,6 +119,20 @@ input:checked ~ .field__other {
       display: flex;
       flex-wrap: wrap;
       width: 100%;
+    }
+  }
+
+  // TEMPORARY: Remove once runner has been refactored to use numeric month field
+
+  &--date {
+    .field--select {
+      flex-shrink: 1;
+    }
+  }
+
+  &--date & {
+    &__fields {
+      flex-wrap: nowrap;
     }
   }
 }


### PR DESCRIPTION
### What is the context of this PR?
Added in temporary fix for date input with dropdown to allow us to run with mobile font size improvements until runner has been updated to use number inputs for the month.
