### PR TITLE
Prevent text from being split across pages on iOS when printing

### DIFF
--- a/assets/sass/partials/base/_print.scss
+++ b/assets/sass/partials/base/_print.scss
@@ -18,6 +18,12 @@
     }
   }
 
+  .page {
+    // Setting overflow-x and min-height to auto prevents iOS from splitting elements across pages when printing.
+    overflow-x: auto;
+    min-height: auto;
+  }
+
   .page__container {
     transform: none !important;
   }


### PR DESCRIPTION
### What is the context of this PR?
Prevents this:
![img_0123](https://user-images.githubusercontent.com/8447446/49646410-d4ba3e00-fa16-11e8-813f-6847f29eb2f3.PNG)

With fix:
![img_0122](https://user-images.githubusercontent.com/8447446/49646428-e4d21d80-fa16-11e8-98e8-48372ef2e5a9.PNG)
