### PR TITLE
Ensure exclusive checkbox value is not cleared

### DIFF
--- a/components/02-form-elements/mutually-exclusive/mutually-exclusive.js
+++ b/components/02-form-elements/mutually-exclusive/mutually-exclusive.js
@@ -40,8 +40,11 @@ export const inputToggle = function(inputEl, voiceOverAlertEl, elType) {
     attr = inputEl.getAttribute('data-value')
   } else {
     const charRef = document.querySelector(`#${inputEl.getAttribute(attrCharLimitRef)}`)
-    attr = inputEl.getAttribute('data-value')
-    inputEl.value = '';
+    attr = inputEl.getAttribute('data-value');
+
+    if (elType !== 'checkbox') {
+      inputEl.value = '';
+    }
 
     if (charRef) {
       updateAvailableChars(inputEl, charRef);

--- a/tests/karma/spec/mutuallyexclusive.spec.js
+++ b/tests/karma/spec/mutuallyexclusive.spec.js
@@ -107,7 +107,7 @@ const strInputsTemplate = `
     </div>
 </fieldset>`;
 
-let elTemplate, checkboxElement, exclusiveGroupElement, voiceOverAlertElement, inputElements;
+let elTemplate, checkboxElement, exclusiveGroupElement, voiceOverAlertElement, inputElements, checkboxValue;
 
 describe('Mutually Exclusive Checkboxes;', function() {
 
@@ -128,7 +128,10 @@ describe('Mutually Exclusive Checkboxes;', function() {
 
   describe('When multiple checkboxes of the group are clicked,', function() {
     exclusiveGroupElement = document.getElementsByClassName(exclusiveGroupClass);
+
+
     before('Click the checkboxes', function() {
+      checkboxValue = checkboxElement[0].value;
       exclusiveGroupElement[0].click();
       exclusiveGroupElement[1].click();
       exclusiveGroupElement[2].click();
@@ -136,6 +139,10 @@ describe('Mutually Exclusive Checkboxes;', function() {
 
     it('should update the live region', function() {
       expect(voiceOverAlertElement[0]).should.not.be.empty;
+    });
+
+    it ('should maintain the value of the checkbox element', function() {
+      expect(checkboxElement[0].value).to.equal(checkboxValue);
     });
   });
 


### PR DESCRIPTION
### What is the context of this PR?
Resolves https://github.com/ONSdigital/sdc-global-design-patterns/issues/236

When filling in a textarea / checking a checkbox option etc in a mutually exclusive component, it was clearing the value of the mutually exclusive checkbox meaning no value is sent to the server in runner, breaking functional tests.